### PR TITLE
Optimizations to event system & Virtual thread for async scheduler

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/scheduler/CraftAsyncScheduler.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/scheduler/CraftAsyncScheduler.java
@@ -14,17 +14,23 @@ import java.util.concurrent.TimeUnit;
 
 public class CraftAsyncScheduler extends CraftScheduler {
 
+    // CatRoom start - Use virtual thread for async scheduler
     private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-            4, Integer.MAX_VALUE,30L, TimeUnit.SECONDS, new SynchronousQueue<>(),
-            new ThreadFactoryBuilder().setNameFormat("Craft Scheduler Thread - %1$d").build());
+            0, Integer.MAX_VALUE,10L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+            new ThreadFactoryBuilder().setThreadFactory(Thread.ofVirtual().factory()).setNameFormat("Craft Scheduler Thread - %1$d").build());
+    // CatRoom end - Use virtual thread for async scheduler
     private final Executor management = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
             .setNameFormat("Craft Async Scheduler Management Thread").build());
     private final List<CraftTask> temp = new ArrayList<>();
 
     CraftAsyncScheduler() {
         super(true);
+        // CatRoom start - Use virtual thread for async scheduler
+        /*
         executor.allowCoreThreadTimeOut(true);
         executor.prestartAllCoreThreads();
+        */
+        // CatRoom end - Use virtual thread for async scheduler
     }
 
     @Override

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -474,6 +474,7 @@ public final class SimplePluginManager implements PluginManager {
      * @param event Event details
      */
     public void callEvent(Event event) {
+        if (event.getHandlers().getRegisteredListeners().length == 0) return; // CatRoom - Skip event if no listeners
         if (CatServer.getConfig().fakePlayerEventPass && event instanceof PlayerEvent && ((PlayerEvent) event).getPlayer() instanceof CraftFakePlayer) return; // CatServer
         if (event.isAsynchronous() || !server.isPrimaryThread()) { // CatServer
             if (Thread.holdsLock(this)) {


### PR DESCRIPTION
This pull request includes following changes:
1. Use virtual thread introduced in Java 21 for CraftAsyncScheduler, which could significantly improve performance of plugin using async tasks.
2. Skip firing event if there's no listener registered