### PR TITLE
Fix simple difficulty

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -644,7 +644,7 @@
          }
  
          PlayerInteractionManager playerinteractionmanager;
-@@ -497,101 +742,226 @@
+@@ -497,101 +742,230 @@
          return new EntityPlayerMP(this.field_72400_f, this.field_72400_f.func_71218_a(0), p_148545_1_, playerinteractionmanager);
      }
  
@@ -777,6 +777,10 @@
 +        EntityPlayerMP entityplayermp = new EntityPlayerMP(this.mcServer, this.mcServer.getWorld(playerIn.dimension), playerIn.getGameProfile(), playerinteractionmanager);
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;
++        // CatRoom start - Call construct event and re-gather capabilities
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(entityplayermp));
++        ((Entity) entityplayermp).capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(entityplayermp);
++        // CatRoom end - Call construct event and re-gather capabilities
 +        org.bukkit.World fromWorld = playerIn.getBukkitEntity().getWorld();
 +        playerIn.field_71136_j = false;
 +
@@ -940,7 +944,7 @@
          return entityplayermp;
      }
  
-@@ -599,75 +969,147 @@
+@@ -599,75 +973,147 @@
      {
          GameProfile gameprofile = p_187243_1_.func_146103_bH();
          int i = this.func_152596_g(gameprofile) ? this.field_72414_i.func_187452_a(gameprofile) : 0;
@@ -1143,7 +1147,7 @@
          {
              BlockPos blockpos;
  
-@@ -693,7 +1135,7 @@
+@@ -693,7 +1139,7 @@
  
          p_82448_3_.field_72984_F.func_76319_b();
  
@@ -1152,7 +1156,7 @@
          {
              p_82448_3_.field_72984_F.func_76320_a("placing");
              d0 = (double)MathHelper.func_76125_a((int)d0, -29999872, 29999872);
-@@ -702,7 +1144,8 @@
+@@ -702,7 +1148,8 @@
              if (p_82448_1_.func_70089_S())
              {
                  p_82448_1_.func_70012_b(d0, p_82448_1_.field_70163_u, d1, p_82448_1_.field_70177_z, p_82448_1_.field_70125_A);
@@ -1162,7 +1166,7 @@
                  p_82448_4_.func_72838_d(p_82448_1_);
                  p_82448_4_.func_72866_a(p_82448_1_, false);
              }
-@@ -713,11 +1156,155 @@
+@@ -713,11 +1160,155 @@
          p_82448_1_.func_70029_a(p_82448_4_);
      }
  
@@ -1319,7 +1323,7 @@
              this.field_72408_o = 0;
          }
      }
-@@ -726,9 +1313,27 @@
+@@ -726,9 +1317,27 @@
      {
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1350,7 +1354,7 @@
  
      public void func_148537_a(Packet<?> p_148537_1_, int p_148537_2_)
      {
-@@ -795,11 +1400,11 @@
+@@ -795,11 +1404,11 @@
                  s = s + ", ";
              }
  
@@ -1364,7 +1368,7 @@
              }
          }
  
-@@ -812,7 +1417,7 @@
+@@ -812,7 +1421,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1373,7 +1377,7 @@
          }
  
          return astring;
-@@ -824,7 +1429,7 @@
+@@ -824,7 +1433,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1382,7 +1386,7 @@
          }
  
          return agameprofile;
-@@ -845,12 +1450,20 @@
+@@ -845,12 +1454,20 @@
          int i = this.field_72400_f.func_110455_j();
          this.field_72414_i.func_152687_a(new UserListOpsEntry(p_152605_1_, this.field_72400_f.func_110455_j(), this.field_72414_i.func_183026_b(p_152605_1_)));
          this.func_187245_a(this.func_177451_a(p_152605_1_.getId()), i);
@@ -1403,7 +1407,7 @@
      }
  
      private void func_187245_a(EntityPlayerMP p_187245_1_, int p_187245_2_)
-@@ -883,11 +1496,7 @@
+@@ -883,11 +1500,7 @@
  
      public boolean func_152596_g(GameProfile p_152596_1_)
      {
@@ -1416,7 +1420,7 @@
      }
  
      @Nullable
-@@ -904,19 +1513,17 @@
+@@ -904,19 +1517,17 @@
          return null;
      }
  
@@ -1443,7 +1447,7 @@
  
              if (entityplayermp != p_148543_1_ && entityplayermp.field_71093_bK == p_148543_10_)
              {
-@@ -976,25 +1583,29 @@
+@@ -976,25 +1587,29 @@
  
      public void func_72354_b(EntityPlayerMP p_72354_1_, WorldServer p_72354_2_)
      {
@@ -1480,7 +1484,7 @@
          p_72385_1_.field_71135_a.func_147359_a(new SPacketHeldItemChange(p_72385_1_.field_71071_by.field_70461_c));
      }
  
-@@ -1010,13 +1621,7 @@
+@@ -1010,13 +1625,7 @@
  
      public String[] func_72373_m()
      {
@@ -1495,7 +1499,7 @@
      }
  
      public void func_72371_a(boolean p_72371_1_)
-@@ -1026,7 +1631,7 @@
+@@ -1026,7 +1635,7 @@
  
      public List<EntityPlayerMP> func_72382_j(String p_72382_1_)
      {
@@ -1504,7 +1508,7 @@
  
          for (EntityPlayerMP entityplayermp : this.field_72404_b)
          {
-@@ -1082,9 +1687,15 @@
+@@ -1082,9 +1691,15 @@
  
      public void func_72392_r()
      {
@@ -1523,7 +1527,7 @@
          }
      }
  
-@@ -1092,7 +1703,10 @@
+@@ -1092,7 +1707,10 @@
      {
          this.field_72400_f.func_145747_a(p_148544_1_);
          ChatType chattype = p_148544_2_ ? ChatType.SYSTEM : ChatType.CHAT;
@@ -1535,7 +1539,7 @@
      }
  
      public void func_148539_a(ITextComponent p_148539_1_)
-@@ -1100,10 +1714,11 @@
+@@ -1100,10 +1718,11 @@
          this.func_148544_a(p_148539_1_, true);
      }
  
@@ -1548,7 +1552,7 @@
  
          if (statisticsmanagerserver == null)
          {
-@@ -1128,6 +1743,8 @@
+@@ -1128,6 +1747,8 @@
          return statisticsmanagerserver;
      }
  
@@ -1557,7 +1561,7 @@
      public PlayerAdvancements func_192054_h(EntityPlayerMP p_192054_1_)
      {
          UUID uuid = p_192054_1_.func_110124_au();
-@@ -1151,7 +1768,7 @@
+@@ -1151,7 +1772,7 @@
  
          if (this.field_72400_f.field_71305_c != null)
          {
@@ -1566,7 +1570,7 @@
              {
                  if (worldserver != null)
                  {
-@@ -1183,5 +1800,11 @@
+@@ -1183,5 +1804,11 @@
          {
              playeradvancements.func_193766_b();
          }

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -773,6 +773,9 @@
 -        entityplayermp.func_184819_a(p_72368_1_.func_184591_cq());
 -
 -        for (String s : p_72368_1_.func_184216_O())
++            playerinteractionmanager = new PlayerInteractionManager(this.mcServer.getWorld(playerIn.dimension));
++        }
++
 +        EntityPlayerMP entityplayermp = new EntityPlayerMP(this.mcServer, this.mcServer.getWorld(playerIn.dimension), playerIn.getGameProfile(), playerinteractionmanager);
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -644,7 +644,7 @@
          }
  
          PlayerInteractionManager playerinteractionmanager;
-@@ -497,101 +742,230 @@
+@@ -497,101 +742,232 @@
          return new EntityPlayerMP(this.field_72400_f, this.field_72400_f.func_71218_a(0), p_148545_1_, playerinteractionmanager);
      }
  
@@ -761,9 +761,8 @@
          else
          {
 -            playerinteractionmanager = new PlayerInteractionManager(this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK));
-+            playerinteractionmanager = new PlayerInteractionManager(this.mcServer.getWorld(playerIn.dimension));
-         }
- 
+-        }
+-
 -        EntityPlayerMP entityplayermp = new EntityPlayerMP(
 -            this.field_72400_f, this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK), p_72368_1_.func_146103_bH(), playerinteractionmanager
 -        );
@@ -778,8 +777,10 @@
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;
 +        // CatRoom start - Call construct event and re-gather capabilities
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(entityplayermp));
-+        ((Entity) entityplayermp).capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(entityplayermp);
++        if (catserver.server.CatServer.getConfig().callConstructCapabilityEventOnRespawn) {
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(entityplayermp));
++            ((Entity) entityplayermp).capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(entityplayermp);
++        }
 +        // CatRoom end - Call construct event and re-gather capabilities
 +        org.bukkit.World fromWorld = playerIn.getBukkitEntity().getWorld();
 +        playerIn.field_71136_j = false;
@@ -944,7 +945,7 @@
          return entityplayermp;
      }
  
-@@ -599,75 +973,147 @@
+@@ -599,75 +975,147 @@
      {
          GameProfile gameprofile = p_187243_1_.func_146103_bH();
          int i = this.func_152596_g(gameprofile) ? this.field_72414_i.func_187452_a(gameprofile) : 0;
@@ -1147,7 +1148,7 @@
          {
              BlockPos blockpos;
  
-@@ -693,7 +1139,7 @@
+@@ -693,7 +1141,7 @@
  
          p_82448_3_.field_72984_F.func_76319_b();
  
@@ -1156,7 +1157,7 @@
          {
              p_82448_3_.field_72984_F.func_76320_a("placing");
              d0 = (double)MathHelper.func_76125_a((int)d0, -29999872, 29999872);
-@@ -702,7 +1148,8 @@
+@@ -702,7 +1150,8 @@
              if (p_82448_1_.func_70089_S())
              {
                  p_82448_1_.func_70012_b(d0, p_82448_1_.field_70163_u, d1, p_82448_1_.field_70177_z, p_82448_1_.field_70125_A);
@@ -1166,7 +1167,7 @@
                  p_82448_4_.func_72838_d(p_82448_1_);
                  p_82448_4_.func_72866_a(p_82448_1_, false);
              }
-@@ -713,11 +1160,155 @@
+@@ -713,11 +1162,155 @@
          p_82448_1_.func_70029_a(p_82448_4_);
      }
  
@@ -1323,7 +1324,7 @@
              this.field_72408_o = 0;
          }
      }
-@@ -726,9 +1317,27 @@
+@@ -726,9 +1319,27 @@
      {
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1354,7 +1355,7 @@
  
      public void func_148537_a(Packet<?> p_148537_1_, int p_148537_2_)
      {
-@@ -795,11 +1404,11 @@
+@@ -795,11 +1406,11 @@
                  s = s + ", ";
              }
  
@@ -1368,7 +1369,7 @@
              }
          }
  
-@@ -812,7 +1421,7 @@
+@@ -812,7 +1423,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1377,7 +1378,7 @@
          }
  
          return astring;
-@@ -824,7 +1433,7 @@
+@@ -824,7 +1435,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1386,7 +1387,7 @@
          }
  
          return agameprofile;
-@@ -845,12 +1454,20 @@
+@@ -845,12 +1456,20 @@
          int i = this.field_72400_f.func_110455_j();
          this.field_72414_i.func_152687_a(new UserListOpsEntry(p_152605_1_, this.field_72400_f.func_110455_j(), this.field_72414_i.func_183026_b(p_152605_1_)));
          this.func_187245_a(this.func_177451_a(p_152605_1_.getId()), i);
@@ -1407,7 +1408,7 @@
      }
  
      private void func_187245_a(EntityPlayerMP p_187245_1_, int p_187245_2_)
-@@ -883,11 +1500,7 @@
+@@ -883,11 +1502,7 @@
  
      public boolean func_152596_g(GameProfile p_152596_1_)
      {
@@ -1420,7 +1421,7 @@
      }
  
      @Nullable
-@@ -904,19 +1517,17 @@
+@@ -904,19 +1519,17 @@
          return null;
      }
  
@@ -1447,7 +1448,7 @@
  
              if (entityplayermp != p_148543_1_ && entityplayermp.field_71093_bK == p_148543_10_)
              {
-@@ -976,25 +1587,29 @@
+@@ -976,25 +1589,29 @@
  
      public void func_72354_b(EntityPlayerMP p_72354_1_, WorldServer p_72354_2_)
      {
@@ -1484,7 +1485,7 @@
          p_72385_1_.field_71135_a.func_147359_a(new SPacketHeldItemChange(p_72385_1_.field_71071_by.field_70461_c));
      }
  
-@@ -1010,13 +1625,7 @@
+@@ -1010,13 +1627,7 @@
  
      public String[] func_72373_m()
      {
@@ -1499,7 +1500,7 @@
      }
  
      public void func_72371_a(boolean p_72371_1_)
-@@ -1026,7 +1635,7 @@
+@@ -1026,7 +1637,7 @@
  
      public List<EntityPlayerMP> func_72382_j(String p_72382_1_)
      {
@@ -1508,7 +1509,7 @@
  
          for (EntityPlayerMP entityplayermp : this.field_72404_b)
          {
-@@ -1082,9 +1691,15 @@
+@@ -1082,9 +1693,15 @@
  
      public void func_72392_r()
      {
@@ -1527,7 +1528,7 @@
          }
      }
  
-@@ -1092,7 +1707,10 @@
+@@ -1092,7 +1709,10 @@
      {
          this.field_72400_f.func_145747_a(p_148544_1_);
          ChatType chattype = p_148544_2_ ? ChatType.SYSTEM : ChatType.CHAT;
@@ -1539,7 +1540,7 @@
      }
  
      public void func_148539_a(ITextComponent p_148539_1_)
-@@ -1100,10 +1718,11 @@
+@@ -1100,10 +1720,11 @@
          this.func_148544_a(p_148539_1_, true);
      }
  
@@ -1552,7 +1553,7 @@
  
          if (statisticsmanagerserver == null)
          {
-@@ -1128,6 +1747,8 @@
+@@ -1128,6 +1749,8 @@
          return statisticsmanagerserver;
      }
  
@@ -1561,7 +1562,7 @@
      public PlayerAdvancements func_192054_h(EntityPlayerMP p_192054_1_)
      {
          UUID uuid = p_192054_1_.func_110124_au();
-@@ -1151,7 +1772,7 @@
+@@ -1151,7 +1774,7 @@
  
          if (this.field_72400_f.field_71305_c != null)
          {
@@ -1570,7 +1571,7 @@
              {
                  if (worldserver != null)
                  {
-@@ -1183,5 +1804,11 @@
+@@ -1183,5 +1806,11 @@
          {
              playeradvancements.func_193766_b();
          }

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -62,6 +62,8 @@ public class CatServerConfig {
     public boolean disableAsyncCatchWarn = false;
     public boolean versionCheck = true;
 
+    public boolean callConstructCapabilityEventOnRespawn = false;
+
     public boolean enableAffinity = false;
     public BitSet affinity = Affinity.getAffinity();
 
@@ -114,6 +116,10 @@ public class CatServerConfig {
         // Event bridge // CatRoom start - Handle mod explosion event
         bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("event-bridge.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
         // CatRoom end - Handle mod explosion event
+        // CatRoom start - Call construct and capability event on respawn
+        // compatibility
+        callConstructCapabilityEventOnRespawn = getOrWriteBooleanConfig("compatibility.callConstructCapabilityEventOnRespawn", callConstructCapabilityEventOnRespawn);
+        // CatRoom end - Call construct and capability event on respawn
         // general
         disableUpdateGameProfile = getOrWriteBooleanConfig("disableUpdateGameProfile", disableUpdateGameProfile);
         disableAsyncCatchWarn = getOrWriteBooleanConfig("disableAsyncCatchWarn", disableAsyncCatchWarn);


### PR DESCRIPTION
This fixes some mechanic inconsistencies in mods like SimpleDifficulty. Vanilla re-create a player instance when a player changes world, CraftBukkit made only single instance per player during its lifecycle(online period). Sadly, we can do nothing for this but call events that broken by CraftBukkit respawn logic.