### PR TITLE
Dont load chunk for Pathfinding & Networking opts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -508,6 +508,7 @@ project(':cleanroom') {
         installer 'net.openhft:affinity:3.23.3'
         installer 'org.slf4j:slf4j-api:2.1.0-alpha1' // Affinity
         installer 'org.slf4j:slf4j-simple:2.1.0-alpha1' // Affinity
+        installer 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
         /*
         forgeGradleMcDeps

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ def jvm_arguments = [
 def compiler_jvm_arguments = [
         '--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED',
         '--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED',
+        '-Xlint:-removal', // Suppress Timings deprecation warnings
         '--add-modules=jdk.incubator.vector' // CatRoom - SIMD support
 ]
 // Projects

--- a/patches/minecraft/net/minecraft/network/NetworkSystem.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetworkSystem.java.patch
@@ -1,6 +1,6 @@
 --- before/net/minecraft/network/NetworkSystem.java
 +++ after/net/minecraft/network/NetworkSystem.java
-@@ -49,27 +49,27 @@
+@@ -49,27 +49,36 @@
      {
          protected NioEventLoopGroup func_179280_b()
          {
@@ -30,10 +30,19 @@
 -    private final List<NetworkManager> field_151272_f = Collections.synchronizedList(Lists.newArrayList());
 +    private final List<ChannelFuture> field_151274_e = Collections.<ChannelFuture>synchronizedList(Lists.newArrayList());
 +    private final List<NetworkManager> field_151272_f = Collections.<NetworkManager>synchronizedList(Lists.newArrayList());
++    // Paper start - prevent blocking on adding a new network manager while the server is ticking
++    private final List<NetworkManager> pending = Collections.<NetworkManager>synchronizedList(Lists.newArrayList());
++    private void addPending() {
++        synchronized (pending) {
++            this.field_151272_f.addAll(pending);
++            pending.clear();
++        }
++    }
++    // Paper end
  
      public NetworkSystem(MinecraftServer p_i45292_1_)
      {
-@@ -79,6 +79,7 @@
+@@ -79,6 +88,7 @@
  
      public void func_151265_a(InetAddress p_151265_1_, int p_151265_2_) throws IOException
      {
@@ -41,7 +50,7 @@
          synchronized (this.field_151274_e)
          {
              Class <? extends ServerSocketChannel > oclass;
-@@ -97,43 +98,26 @@
+@@ -97,43 +107,26 @@
                  field_151275_b.info("Using default channel type");
              }
  
@@ -76,7 +85,8 @@
 -                    .addLast("encoder", new NettyPacketEncoder(EnumPacketDirection.CLIENTBOUND));
 +                    p_initChannel_1_.pipeline().addLast("timeout", new ReadTimeoutHandler(net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.READ_TIMEOUT)).addLast("legacy_query", new LegacyPingHandler(NetworkSystem.this)).addLast("splitter", new NettyVarint21FrameDecoder()).addLast("decoder", new NettyPacketDecoder(EnumPacketDirection.SERVERBOUND)).addLast("prepender", new NettyVarint21FrameEncoder()).addLast("encoder", new NettyPacketEncoder(EnumPacketDirection.CLIENTBOUND));
                      NetworkManager networkmanager = new NetworkManager(EnumPacketDirection.SERVERBOUND);
-                     NetworkSystem.this.field_151272_f.add(networkmanager);
+-                    NetworkSystem.this.field_151272_f.add(networkmanager);
++                    pending.add(networkmanager);
                      p_initChannel_1_.pipeline().addLast("packet_handler", networkmanager);
                      networkmanager.func_150719_a(new NetHandlerHandshakeTCP(NetworkSystem.this.field_151273_d, networkmanager));
                  }
@@ -91,7 +101,7 @@
          }
      }
  
-@@ -144,9 +128,8 @@
+@@ -144,9 +137,8 @@
  
          synchronized (this.field_151274_e)
          {
@@ -102,7 +112,7 @@
                  protected void initChannel(Channel p_initChannel_1_) throws Exception
                  {
                      NetworkManager networkmanager = new NetworkManager(EnumPacketDirection.SERVERBOUND);
-@@ -154,7 +137,7 @@
+@@ -154,7 +146,7 @@
                      NetworkSystem.this.field_151272_f.add(networkmanager);
                      p_initChannel_1_.pipeline().addLast("packet_handler", networkmanager);
                  }
@@ -111,7 +121,7 @@
              this.field_151274_e.add(channelfuture);
          }
  
-@@ -171,7 +154,7 @@
+@@ -171,7 +163,7 @@
              {
                  channelfuture.channel().close().sync();
              }
@@ -120,11 +130,12 @@
              {
                  field_151275_b.error("Interrupted whilst closing channel");
              }
-@@ -182,6 +165,13 @@
+@@ -182,6 +174,14 @@
      {
          synchronized (this.field_151272_f)
          {
 +            // Spigot Start
++            addPending(); // Paper
 +            // This prevents players from 'gaming' the server, and strategically relogging to increase their position in the tick order
 +            if (org.spigotmc.SpigotConfig.playerShuffle > 0 && MinecraftServer.currentTick % org.spigotmc.SpigotConfig.playerShuffle == 0)
 +            {
@@ -134,7 +145,7 @@
              Iterator<NetworkManager> iterator = this.field_151272_f.iterator();
  
              while (iterator.hasNext())
-@@ -216,7 +206,6 @@
+@@ -216,7 +216,6 @@
                              final TextComponentString textcomponentstring = new TextComponentString("Internal server error");
                              networkmanager.func_179288_a(new SPacketDisconnect(textcomponentstring), new GenericFutureListener < Future <? super Void >> ()
                              {
@@ -142,7 +153,7 @@
                                  public void operationComplete(Future <? super Void > p_operationComplete_1_) throws Exception
                                  {
                                      networkmanager.func_150718_a(textcomponentstring);
-@@ -227,6 +216,9 @@
+@@ -227,6 +226,9 @@
                      }
                      else
                      {

--- a/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
@@ -19,16 +19,19 @@
  
  public class NetHandlerLoginServer implements INetHandlerLoginServer, ITickable
  {
-@@ -49,6 +54,8 @@
+@@ -48,6 +53,11 @@
+     private final String field_147334_j = "";
      private SecretKey field_147335_k;
      private EntityPlayerMP field_181025_l;
- 
-+    public String hostname = "";
++    private static final com.github.benmanes.caffeine.cache.Cache<String, GameProfile> playerProfileResultCache = com.github.benmanes.caffeine.cache.Caffeine.newBuilder()
++            .expireAfterWrite(catserver.server.CatServer.getConfig().playerProfileResultCacheMinutes, java.util.concurrent.TimeUnit.MINUTES)
++            .build(); // CatRoom - Cache player profile result
 +
++    public String hostname = "";
+ 
      public NetHandlerLoginServer(MinecraftServer p_i45298_1_, NetworkManager p_i45298_2_)
      {
-         this.field_147327_f = p_i45298_1_;
-@@ -56,7 +63,6 @@
+@@ -56,7 +66,6 @@
          field_147329_d.nextBytes(this.field_147330_e);
      }
  
@@ -36,7 +39,7 @@
      public void func_73660_a()
      {
          if (this.field_147328_g == NetHandlerLoginServer.LoginState.READY_TO_ACCEPT)
-@@ -70,16 +76,29 @@
+@@ -70,16 +79,29 @@
              if (entityplayermp == null)
              {
                  this.field_147328_g = NetHandlerLoginServer.LoginState.READY_TO_ACCEPT;
@@ -70,7 +73,7 @@
  
      public void func_194026_b(ITextComponent p_194026_1_)
      {
-@@ -95,18 +114,48 @@
+@@ -95,18 +117,48 @@
          }
      }
  
@@ -126,7 +129,7 @@
          }
          else
          {
-@@ -133,12 +182,11 @@
+@@ -133,12 +185,11 @@
              }
              else
              {
@@ -140,7 +143,7 @@
      public void func_147231_a(ITextComponent p_147231_1_)
      {
          field_147332_c.info("{} lost connection: {}", this.func_147317_d(), p_147231_1_.func_150260_c());
-@@ -146,12 +194,9 @@
+@@ -146,12 +197,9 @@
  
      public String func_147317_d()
      {
@@ -154,7 +157,7 @@
      public void func_147316_a(CPacketLoginStart p_147316_1_)
      {
          Validate.validState(this.field_147328_g == NetHandlerLoginServer.LoginState.HELLO, "Unexpected hello packet");
-@@ -164,11 +209,24 @@
+@@ -164,11 +212,24 @@
          }
          else
          {
@@ -181,7 +184,7 @@
      public void func_147315_a(CPacketEncryptionResponse p_147315_1_)
      {
          Validate.validState(this.field_147328_g == NetHandlerLoginServer.LoginState.KEY, "Unexpected key packet");
-@@ -183,32 +241,28 @@
+@@ -183,32 +244,39 @@
              this.field_147335_k = p_147315_1_.func_149300_a(privatekey);
              this.field_147328_g = NetHandlerLoginServer.LoginState.AUTHENTICATING;
              this.field_147333_a.func_150727_a(this.field_147335_k);
@@ -208,7 +211,18 @@
 -                                .func_147130_as()
 -                                .hasJoinedServer(new GameProfile(null, gameprofile.getName()), s, this.func_191235_a());
 +                        String s = (new BigInteger(CryptManager.func_75895_a("", NetHandlerLoginServer.this.field_147327_f.func_71250_E().getPublic(), NetHandlerLoginServer.this.field_147335_k))).toString(16);
-+                        NetHandlerLoginServer.this.field_147337_i = NetHandlerLoginServer.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID) null, gameprofile.getName()), s, this.func_191235_a());
++                        // CatRoom start - Cache player profile result
++                        if (catserver.server.CatServer.getConfig().cachePlayerProfileResult) {
++                            GameProfile gp = playerProfileResultCache.getIfPresent(gameprofile.getName());
++                            if (gp == null) {
++                                gp = NetHandlerLoginServer.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID)null, gameprofile.getName()), s, this.func_191235_a());
++                                playerProfileResultCache.put(gameprofile.getName(), gp);
++                            }
++                            NetHandlerLoginServer.this.field_147337_i = gp;
++                        } else {
++                            NetHandlerLoginServer.this.field_147337_i = NetHandlerLoginServer.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID) null, gameprofile.getName()), s, this.func_191235_a());
++                        }
++                        // CatRoom end - Cache player profile result
  
                          if (NetHandlerLoginServer.this.field_147337_i != null)
                          {
@@ -226,7 +240,7 @@
                          }
                          else if (NetHandlerLoginServer.this.field_147327_f.func_71264_H())
                          {
-@@ -218,11 +272,11 @@
+@@ -218,11 +286,11 @@
                          }
                          else
                          {
@@ -241,7 +255,7 @@
                      {
                          if (NetHandlerLoginServer.this.field_147327_f.func_71264_H())
                          {
-@@ -232,23 +286,67 @@
+@@ -232,23 +300,67 @@
                          }
                          else
                          {

--- a/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
@@ -154,24 +154,25 @@
      public void func_147316_a(CPacketLoginStart p_147316_1_)
      {
          Validate.validState(this.field_147328_g == NetHandlerLoginServer.LoginState.HELLO, "Unexpected hello packet");
-@@ -164,11 +209,23 @@
+@@ -164,11 +209,24 @@
          }
          else
          {
 -            this.field_147328_g = NetHandlerLoginServer.LoginState.READY_TO_ACCEPT;
 +            // Spigot start
-+            new Thread(net.minecraftforge.fml.common.thread.SidedThreadGroups.SERVER, "User Authenticator #" + NetHandlerLoginServer.field_147331_b.incrementAndGet()) {
-+                @Override
-+                public void run() {
-+                    try {
-+                        initUUID();
-+                        new LoginHandler().fireEvents();
-+                    } catch (Exception ex) {
-+                        disconnect("Failed to verify username!");
-+                        field_147327_f.server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + field_147337_i.getName(), ex);
-+                    }
-+                }
-+            }.start();
++            // CatRoom start - Virtual thread for User Authenticator
++            Thread.ofVirtual()
++                    .name("User Authenticator #" + NetHandlerLoginServer.field_147331_b.incrementAndGet())
++                    .start(() -> {
++                        try {
++                            initUUID();
++                            new LoginHandler().fireEvents();
++                        } catch (Exception ex) {
++                            disconnect("Failed to verify username!");
++                            field_147327_f.server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + field_147337_i.getName(), ex);
++                        }
++                    });
++            // CatRoom end - Virtual thread for User Authenticator
 +            // Spigot end
          }
      }
@@ -180,12 +181,15 @@
      public void func_147315_a(CPacketEncryptionResponse p_147315_1_)
      {
          Validate.validState(this.field_147328_g == NetHandlerLoginServer.LoginState.KEY, "Unexpected key packet");
-@@ -183,32 +240,25 @@
+@@ -183,32 +241,28 @@
              this.field_147335_k = p_147315_1_.func_149300_a(privatekey);
              this.field_147328_g = NetHandlerLoginServer.LoginState.AUTHENTICATING;
              this.field_147333_a.func_150727_a(this.field_147335_k);
 -            (new Thread("User Authenticator #" + field_147331_b.incrementAndGet())
-+            (new Thread(net.minecraftforge.fml.common.thread.SidedThreadGroups.SERVER, "User Authenticator #" + field_147331_b.incrementAndGet())
++            // CatRoom start - Virtual thread for User Authenticator
++            Thread.ofVirtual()
++                    .name("User Authenticator #" + field_147331_b.incrementAndGet())
++                    .start(new Runnable() // CatRoom end - Virtual thread for User Authenticator
              {
 -                @Override
                  public void run()
@@ -204,7 +208,7 @@
 -                                .func_147130_as()
 -                                .hasJoinedServer(new GameProfile(null, gameprofile.getName()), s, this.func_191235_a());
 +                        String s = (new BigInteger(CryptManager.func_75895_a("", NetHandlerLoginServer.this.field_147327_f.func_71250_E().getPublic(), NetHandlerLoginServer.this.field_147335_k))).toString(16);
-+                        NetHandlerLoginServer.this.field_147337_i = NetHandlerLoginServer.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID)null, gameprofile.getName()), s, this.getAddress());
++                        NetHandlerLoginServer.this.field_147337_i = NetHandlerLoginServer.this.field_147327_f.func_147130_as().hasJoinedServer(new GameProfile((UUID) null, gameprofile.getName()), s, this.func_191235_a());
  
                          if (NetHandlerLoginServer.this.field_147337_i != null)
                          {
@@ -222,7 +226,7 @@
                          }
                          else if (NetHandlerLoginServer.this.field_147327_f.func_71264_H())
                          {
-@@ -218,11 +268,11 @@
+@@ -218,11 +272,11 @@
                          }
                          else
                          {
@@ -237,7 +241,7 @@
                      {
                          if (NetHandlerLoginServer.this.field_147327_f.func_71264_H())
                          {
-@@ -232,23 +282,67 @@
+@@ -232,23 +286,67 @@
                          }
                          else
                          {
@@ -254,8 +258,7 @@
                      }
                  }
                  @Nullable
--                private InetAddress func_191235_a()
-+                private InetAddress getAddress()
+                 private InetAddress func_191235_a()
                  {
                      SocketAddress socketaddress = NetHandlerLoginServer.this.field_147333_a.func_74430_c();
 -                    return NetHandlerLoginServer.this.field_147327_f.func_190518_ac() && socketaddress instanceof InetSocketAddress
@@ -268,7 +271,7 @@
 -    }
 +                    return NetHandlerLoginServer.this.field_147327_f.func_190518_ac() && socketaddress instanceof InetSocketAddress ? ((InetSocketAddress)socketaddress).getAddress() : null;
 +                }
-+            }).start();
++            }); // CatRoom
 +        }
 +    }
 +

--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -1,5 +1,14 @@
 --- before/net/minecraft/world/ChunkCache.java
 +++ after/net/minecraft/world/ChunkCache.java
+@@ -34,7 +34,7 @@
+         {
+             for (int l = this.field_72816_b; l <= j; ++l)
+             {
+-                this.field_72817_c[k - this.field_72818_a][l - this.field_72816_b] = p_i45746_1_.func_72964_e(k, l);
++                this.field_72817_c[k - this.field_72818_a][l - this.field_72816_b] = p_i45746_1_.getChunkIfLoaded(k, l); // Paper
+             }
+         }
+ 
 @@ -59,10 +59,9 @@
      }
  

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -48,8 +48,6 @@ public class CatServerConfig {
 
     public boolean waitForgeServerChatEvent = false;
 
-    public boolean bridgeForgeExplosionEventToBukkit = true; // CatRoom
-
     public int craftRequestThrottle = 20;
     public int itemNBTThrottle = 200;
     public boolean limitFastClickGUI = false;
@@ -65,6 +63,7 @@ public class CatServerConfig {
     public int playerProfileResultCacheMinutes = 1440;
 
     public boolean callConstructCapabilityEventOnRespawn = false;
+    public boolean bridgeForgeExplosionEventToBukkit = false;
 
     public boolean enableAffinity = false;
     public BitSet affinity = Affinity.getAffinity();
@@ -117,10 +116,9 @@ public class CatServerConfig {
         disableFMLStatusModInfo = getOrWriteBooleanConfig("network.fml.disableStatusModInfo", config.getBoolean("disableFMLStatusModInfo", disableFMLStatusModInfo));
         cachePlayerProfileResult = getOrWriteBooleanConfig("network.profile.cachePlayerProfileResult", cachePlayerProfileResult);
         playerProfileResultCacheMinutes = getOrWriteIntConfig("network.profile.playerProfileResultCacheMinutes", playerProfileResultCacheMinutes);
-        // event bridge
-        bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("event-bridge.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
         // compatibility
         callConstructCapabilityEventOnRespawn = getOrWriteBooleanConfig("compatibility.callConstructCapabilityEventOnRespawn", callConstructCapabilityEventOnRespawn);
+        bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("compatibility.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
         // general
         disableUpdateGameProfile = getOrWriteBooleanConfig("disableUpdateGameProfile", disableUpdateGameProfile);
         disableAsyncCatchWarn = getOrWriteBooleanConfig("disableAsyncCatchWarn", disableAsyncCatchWarn);

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -61,6 +61,8 @@ public class CatServerConfig {
     public boolean disableFMLStatusModInfo = false;
     public boolean disableAsyncCatchWarn = false;
     public boolean versionCheck = true;
+    public boolean cachePlayerProfileResult = false;
+    public int playerProfileResultCacheMinutes = 1440;
 
     public boolean callConstructCapabilityEventOnRespawn = false;
 
@@ -113,6 +115,8 @@ public class CatServerConfig {
         releaseUseItemThrottle = getOrWriteIntConfig("network.packetLimit.releaseUseItemThrottle", releaseUseItemThrottle);
         disableFMLHandshake = getOrWriteBooleanConfig("network.fml.disableHandshake", config.getBoolean("disableFMLHandshake", disableFMLHandshake));
         disableFMLStatusModInfo = getOrWriteBooleanConfig("network.fml.disableStatusModInfo", config.getBoolean("disableFMLStatusModInfo", disableFMLStatusModInfo));
+        cachePlayerProfileResult = getOrWriteBooleanConfig("network.profile.cachePlayerProfileResult", cachePlayerProfileResult);
+        playerProfileResultCacheMinutes = getOrWriteIntConfig("network.profile.playerProfileResultCacheMinutes", playerProfileResultCacheMinutes);
         // event bridge
         bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("event-bridge.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
         // compatibility


### PR DESCRIPTION
This pull request includes:
- Dont load chunk for pathfinding
- Prevent blocking on adding a new network manager while the server is ticking
- Virtual thread for User Authenticator
- Cache PlayerProfile result