### PR TITLE
Fix cb respawn logic

### DIFF
--- a/FIXED_UPSTREAM_ISSUES.md
+++ b/FIXED_UPSTREAM_ISSUES.md
@@ -2,7 +2,7 @@
 
 ### Modpacks
 
-- Cannot launch MC Eternal[(CatServer#904)](https://github.com/Luohuayu/CatServer/issues/904)
+- Cannot launch MC Eternal[(Luohuayu/CatServer#904)](https://github.com/Luohuayu/CatServer/issues/904)
 
 ### Forge-Bukkit
 
@@ -11,5 +11,6 @@
 ### Mods
 
 - Simple Difficulty(And any other similar mods) thirst is not getting reset on player respawn[(Luohuayu/CatServer#536)](https://github.com/Luohuayu/CatServer/issues/536)[(MohistMC/Mohist#2905)](https://github.com/MohistMC/Mohist/issues/2905)
+- Ring dupe bug in The Betweenlands mod[(Luohuayu/CatServer#204)](https://github.com/Luohuayu/CatServer/issues/204)
 
 **All fixes have been contributed to the upstream project.**

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -68,7 +68,7 @@
      protected int field_184245_j;
      private Entity field_184239_as;
      public boolean field_98038_p;
-@@ -137,18 +175,18 @@
+@@ -137,18 +175,20 @@
      public float field_70144_Y;
      protected Random field_70146_Z;
      public int field_70173_aa;
@@ -86,16 +86,18 @@
 -    private static final DataParameter<Boolean> field_184233_aA = EntityDataManager.func_187226_a(Entity.class, DataSerializers.field_187198_h);
 -    private static final DataParameter<Boolean> field_184234_aB = EntityDataManager.func_187226_a(Entity.class, DataSerializers.field_187198_h);
 -    private static final DataParameter<Boolean> field_189655_aD = EntityDataManager.func_187226_a(Entity.class, DataSerializers.field_187198_h);
-+    protected static final DataParameter<Byte> field_184240_ax = EntityDataManager.<Byte>func_187226_a(Entity.class, DataSerializers.field_187191_a);
-+    private static final DataParameter<Integer> field_184241_ay = EntityDataManager.<Integer>func_187226_a(Entity.class, DataSerializers.field_187192_b);
-+    private static final DataParameter<String> field_184242_az = EntityDataManager.<String>func_187226_a(Entity.class, DataSerializers.field_187194_d);
-+    private static final DataParameter<Boolean> field_184233_aA = EntityDataManager.<Boolean>func_187226_a(Entity.class, DataSerializers.field_187198_h);
-+    private static final DataParameter<Boolean> field_184234_aB = EntityDataManager.<Boolean>func_187226_a(Entity.class, DataSerializers.field_187198_h);
-+    private static final DataParameter<Boolean> field_189655_aD = EntityDataManager.<Boolean>func_187226_a(Entity.class, DataSerializers.field_187198_h);
++    public static final DataParameter<Byte> field_184240_ax = EntityDataManager.<Byte>func_187226_a(Entity.class, DataSerializers.field_187191_a); // CatRoom - protected -> public
++    // CatRoom start - private -> public
++    public static final DataParameter<Integer> field_184241_ay = EntityDataManager.<Integer>func_187226_a(Entity.class, DataSerializers.field_187192_b);
++    public static final DataParameter<String> field_184242_az = EntityDataManager.<String>func_187226_a(Entity.class, DataSerializers.field_187194_d);
++    public static final DataParameter<Boolean> field_184233_aA = EntityDataManager.<Boolean>func_187226_a(Entity.class, DataSerializers.field_187198_h);
++    public static final DataParameter<Boolean> field_184234_aB = EntityDataManager.<Boolean>func_187226_a(Entity.class, DataSerializers.field_187198_h);
++    public static final DataParameter<Boolean> field_189655_aD = EntityDataManager.<Boolean>func_187226_a(Entity.class, DataSerializers.field_187198_h);
++    // CatRoom end
      public boolean field_70175_ag;
      public int field_70176_ah;
      public int field_70162_ai;
-@@ -172,16 +210,41 @@
+@@ -172,16 +212,41 @@
      protected UUID field_96093_i;
      protected String field_189513_ar;
      private final CommandResultStats field_174837_as;
@@ -139,7 +141,7 @@
          this.field_70121_D = field_174836_a;
          this.field_70130_N = 0.6F;
          this.field_70131_O = 1.8F;
-@@ -193,25 +256,40 @@
+@@ -193,25 +258,40 @@
          this.field_96093_i = MathHelper.func_180182_a(this.field_70146_Z);
          this.field_189513_ar = this.field_96093_i.toString();
          this.field_174837_as = new CommandResultStats();
@@ -189,7 +191,7 @@
  
      public int func_145782_y()
      {
-@@ -258,7 +336,6 @@
+@@ -258,7 +338,6 @@
          return this.field_70180_af;
      }
  
@@ -197,7 +199,7 @@
      public boolean equals(Object p_equals_1_)
      {
          if (p_equals_1_ instanceof Entity)
-@@ -271,7 +348,6 @@
+@@ -271,7 +350,6 @@
          }
      }
  
@@ -205,7 +207,7 @@
      public int hashCode()
      {
          return this.field_145783_c;
-@@ -282,7 +358,7 @@
+@@ -282,7 +360,7 @@
      {
          if (this.field_70170_p != null)
          {
@@ -214,7 +216,7 @@
              {
                  this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
  
-@@ -294,9 +370,9 @@
+@@ -294,9 +372,9 @@
                  ++this.field_70163_u;
              }
  
@@ -227,7 +229,7 @@
              this.field_70125_A = 0.0F;
          }
      }
-@@ -320,41 +396,50 @@
+@@ -320,41 +398,50 @@
  
              if (this.field_70130_N < f)
              {
@@ -301,7 +303,7 @@
          this.field_70177_z = p_70101_1_ % 360.0F;
          this.field_70125_A = p_70101_2_ % 360.0F;
      }
-@@ -364,11 +449,10 @@
+@@ -364,11 +451,10 @@
          this.field_70165_t = p_70107_1_;
          this.field_70163_u = p_70107_3_;
          this.field_70161_v = p_70107_5_;
@@ -315,7 +317,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -376,8 +460,8 @@
+@@ -376,8 +462,8 @@
      {
          float f = this.field_70125_A;
          float f1 = this.field_70177_z;
@@ -326,7 +328,7 @@
          this.field_70125_A = MathHelper.func_76131_a(this.field_70125_A, -90.0F, 90.0F);
          this.field_70127_C += this.field_70125_A - f;
          this.field_70126_B += this.field_70177_z - f1;
-@@ -398,6 +482,49 @@
+@@ -398,6 +484,49 @@
          this.func_70030_z();
      }
  
@@ -376,7 +378,7 @@
      public void func_70030_z()
      {
          this.field_70170_p.field_72984_F.func_76320_a("entityBaseTick");
-@@ -418,28 +545,29 @@
+@@ -418,28 +547,29 @@
          this.field_70166_s = this.field_70161_v;
          this.field_70127_C = this.field_70125_A;
          this.field_70126_B = this.field_70177_z;
@@ -418,7 +420,7 @@
                              {
                                  j = 0;
                              }
-@@ -448,30 +576,30 @@
+@@ -448,30 +578,30 @@
                                  j = -1;
                              }
  
@@ -458,7 +460,7 @@
          this.func_174830_Y();
          this.func_70072_I();
  
-@@ -507,7 +635,7 @@
+@@ -507,7 +637,7 @@
              this.field_70143_R *= 0.5F;
          }
  
@@ -467,7 +469,7 @@
          {
              this.func_70076_C();
          }
-@@ -539,11 +667,31 @@
+@@ -539,11 +669,31 @@
          if (!this.field_70178_ae)
          {
              this.func_70097_a(DamageSource.field_76371_c, 4.0F);
@@ -501,7 +503,7 @@
      {
          int i = p_70015_1_ * 20;
  
-@@ -581,6 +729,7 @@
+@@ -581,6 +731,7 @@
  
      public void func_70091_d(MoverType p_70091_1_, double p_70091_2_, double p_70091_4_, double p_70091_6_)
      {
@@ -509,7 +511,7 @@
          if (this.field_70145_X)
          {
              this.func_174826_a(this.func_174813_aQ().func_72317_d(p_70091_2_, p_70091_4_, p_70091_6_));
-@@ -588,53 +737,69 @@
+@@ -588,53 +739,69 @@
          }
          else
          {
@@ -589,7 +591,7 @@
                      {
                          return;
                      }
-@@ -649,12 +814,12 @@
+@@ -649,12 +816,12 @@
              if (this.field_70134_J)
              {
                  this.field_70134_J = false;
@@ -608,7 +610,7 @@
              }
  
              double d2 = p_70091_2_;
-@@ -663,81 +828,66 @@
+@@ -663,81 +830,66 @@
  
              if ((p_70091_1_ == MoverType.SELF || p_70091_1_ == MoverType.PLAYER) && this.field_70122_E && this.func_70093_af() && this instanceof EntityPlayer)
              {
@@ -740,7 +742,7 @@
                      }
                  }
              }
-@@ -745,49 +895,49 @@
+@@ -745,49 +897,49 @@
              List<AxisAlignedBB> list1 = this.field_70170_p.func_184144_a(this, this.func_174813_aQ().func_72321_a(p_70091_2_, p_70091_4_, p_70091_6_));
              AxisAlignedBB axisalignedbb = this.func_174813_aQ();
  
@@ -802,7 +804,7 @@
  
              if (this.field_70138_W > 0.0F && flag && (d2 != p_70091_2_ || d4 != p_70091_6_))
              {
-@@ -799,62 +949,62 @@
+@@ -799,62 +951,62 @@
                  p_70091_4_ = (double)this.field_70138_W;
                  List<AxisAlignedBB> list = this.field_70170_p.func_184144_a(this, this.func_174813_aQ().func_72321_a(d2, p_70091_4_, d4));
                  AxisAlignedBB axisalignedbb2 = this.func_174813_aQ();
@@ -878,7 +880,7 @@
                  double d23 = d18 * d18 + d19 * d19;
                  double d9 = d21 * d21 + d22 * d22;
  
-@@ -870,17 +1020,17 @@
+@@ -870,17 +1022,17 @@
                      p_70091_2_ = d21;
                      p_70091_6_ = d22;
                      p_70091_4_ = -d20;
@@ -899,7 +901,7 @@
  
                  if (d14 * d14 + d7 * d7 >= p_70091_2_ * p_70091_2_ + p_70091_6_ * p_70091_6_)
                  {
-@@ -896,10 +1046,10 @@
+@@ -896,10 +1048,10 @@
              this.func_174829_m();
              this.field_70123_F = d2 != p_70091_2_ || d4 != p_70091_6_;
              this.field_70124_G = d3 != p_70091_4_;
@@ -912,7 +914,7 @@
              int k6 = MathHelper.func_76128_c(this.field_70161_v);
              BlockPos blockpos = new BlockPos(j6, i1, k6);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
-@@ -921,12 +1071,12 @@
+@@ -921,12 +1073,12 @@
  
              if (d2 != p_70091_2_)
              {
@@ -927,7 +929,7 @@
              }
  
              Block block = iblockstate.func_177230_c();
-@@ -936,6 +1086,26 @@
+@@ -936,6 +1088,26 @@
                  block.func_176216_a(this.field_70170_p, this);
              }
  
@@ -954,7 +956,7 @@
              if (this.func_70041_e_() && (!this.field_70122_E || !this.func_70093_af() || !(this instanceof EntityPlayer)) && !this.func_184218_aH())
              {
                  double d15 = this.field_70165_t - d10;
-@@ -944,7 +1114,7 @@
+@@ -944,7 +1116,7 @@
  
                  if (block != Blocks.field_150468_ap)
                  {
@@ -963,7 +965,7 @@
                  }
  
                  if (block != null && this.field_70122_E)
-@@ -952,8 +1122,8 @@
+@@ -952,8 +1124,8 @@
                      block.func_176199_a(this.field_70170_p, blockpos, this);
                  }
  
@@ -974,7 +976,7 @@
  
                  if (this.field_82151_R > (float)this.field_70150_b && iblockstate.func_185904_a() != Material.field_151579_a)
                  {
-@@ -963,12 +1133,7 @@
+@@ -963,12 +1135,7 @@
                      {
                          Entity entity = this.func_184207_aI() && this.func_184179_bs() != null ? this.func_184179_bs() : this;
                          float f = entity == this ? 0.35F : 0.4F;
@@ -988,7 +990,7 @@
  
                          if (f1 > 1.0F)
                          {
-@@ -987,22 +1152,25 @@
+@@ -987,22 +1154,25 @@
                      this.field_191959_ay = this.func_191954_d(this.field_82151_R);
                  }
              }
@@ -1020,7 +1022,7 @@
              {
                  this.func_70081_e(1);
  
-@@ -1012,7 +1180,13 @@
+@@ -1012,7 +1182,13 @@
  
                      if (this.field_190534_ay == 0)
                      {
@@ -1035,7 +1037,7 @@
                      }
                  }
              }
-@@ -1029,14 +1203,16 @@
+@@ -1029,14 +1205,16 @@
  
              this.field_70170_p.field_72984_F.func_76319_b();
          }
@@ -1054,7 +1056,7 @@
      }
  
      protected SoundEvent func_184184_Z()
-@@ -1049,15 +1225,16 @@
+@@ -1049,15 +1227,16 @@
          return SoundEvents.field_187547_bF;
      }
  
@@ -1077,7 +1079,7 @@
          BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos2 = BlockPos.PooledMutableBlockPos.func_185346_s();
  
          if (this.field_70170_p.func_175707_a(blockpos$pooledmutableblockpos, blockpos$pooledmutableblockpos1))
-@@ -1099,7 +1276,7 @@
+@@ -1099,7 +1278,7 @@
  
      protected void func_180429_a(BlockPos p_180429_1_, Block p_180429_2_)
      {
@@ -1086,7 +1088,7 @@
  
          if (this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c() == Blocks.field_150431_aC)
          {
-@@ -1126,29 +1303,28 @@
+@@ -1126,29 +1305,28 @@
      {
          if (!this.func_174814_R())
          {
@@ -1121,7 +1123,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -1167,7 +1343,7 @@
+@@ -1167,7 +1345,7 @@
  
              this.field_70143_R = 0.0F;
          }
@@ -1130,7 +1132,7 @@
          {
              this.field_70143_R = (float)((double)this.field_70143_R - p_184231_1_);
          }
-@@ -1187,6 +1363,14 @@
+@@ -1187,6 +1365,14 @@
          }
      }
  
@@ -1145,7 +1147,7 @@
      public final boolean func_70045_F()
      {
          return this.field_70178_ae;
-@@ -1211,15 +1395,9 @@
+@@ -1211,15 +1397,9 @@
          }
          else
          {
@@ -1163,7 +1165,7 @@
              {
                  blockpos$pooledmutableblockpos.func_185344_t();
                  return false;
-@@ -1239,7 +1417,7 @@
+@@ -1239,7 +1419,7 @@
  
      public boolean func_191953_am()
      {
@@ -1172,7 +1174,7 @@
      }
  
      public boolean func_70072_I()
-@@ -1248,7 +1426,7 @@
+@@ -1248,7 +1428,7 @@
          {
              this.field_70171_ac = false;
          }
@@ -1181,7 +1183,7 @@
          {
              if (!this.field_70171_ac && !this.field_70148_d)
              {
-@@ -1271,12 +1449,7 @@
+@@ -1271,12 +1451,7 @@
      {
          Entity entity = this.func_184207_aI() && this.func_184179_bs() != null ? this.func_184179_bs() : this;
          float f = entity == this ? 0.2F : 0.9F;
@@ -1195,7 +1197,7 @@
  
          if (f1 > 1.0F)
          {
-@@ -1290,32 +1463,14 @@
+@@ -1290,32 +1465,14 @@
          {
              float f3 = (this.field_70146_Z.nextFloat() * 2.0F - 1.0F) * this.field_70130_N;
              float f4 = (this.field_70146_Z.nextFloat() * 2.0F - 1.0F) * this.field_70130_N;
@@ -1230,7 +1232,7 @@
          }
      }
  
-@@ -1330,24 +1485,15 @@
+@@ -1330,24 +1487,15 @@
      protected void func_174808_Z()
      {
          int i = MathHelper.func_76128_c(this.field_70165_t);
@@ -1258,7 +1260,7 @@
          }
      }
  
-@@ -1363,12 +1509,12 @@
+@@ -1363,12 +1511,12 @@
              BlockPos blockpos = new BlockPos(this.field_70165_t, d0, this.field_70161_v);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
  
@@ -1275,7 +1277,7 @@
              }
              else
              {
-@@ -1379,14 +1525,14 @@
+@@ -1379,14 +1527,14 @@
  
      public boolean func_180799_ab()
      {
@@ -1292,7 +1294,7 @@
          {
              f = MathHelper.func_76129_c(f);
  
-@@ -1396,11 +1542,11 @@
+@@ -1396,11 +1544,11 @@
              }
  
              f = p_191958_4_ / f;
@@ -1309,7 +1311,7 @@
              this.field_70159_w += (double)(p_191958_1_ * f2 - p_191958_3_ * f1);
              this.field_70181_x += (double)p_191958_2_;
              this.field_70179_y += (double)(p_191958_3_ * f2 + p_191958_1_ * f1);
-@@ -1410,9 +1556,7 @@
+@@ -1410,9 +1558,7 @@
      @SideOnly(Side.CLIENT)
      public int func_70070_b()
      {
@@ -1320,7 +1322,7 @@
  
          if (this.field_70170_p.func_175667_e(blockpos$mutableblockpos))
          {
-@@ -1427,9 +1571,7 @@
+@@ -1427,9 +1573,7 @@
  
      public float func_70013_c()
      {
@@ -1331,7 +1333,7 @@
  
          if (this.field_70170_p.func_175667_e(blockpos$mutableblockpos))
          {
-@@ -1444,14 +1586,19 @@
+@@ -1444,14 +1588,19 @@
  
      public void func_70029_a(World p_70029_1_)
      {
@@ -1353,7 +1355,7 @@
          this.field_70169_q = this.field_70165_t;
          this.field_70167_r = this.field_70163_u;
          this.field_70166_s = this.field_70161_v;
-@@ -1462,25 +1609,24 @@
+@@ -1462,25 +1611,24 @@
          this.field_70127_C = this.field_70125_A;
          double d0 = (double)(this.field_70126_B - p_70080_7_);
  
@@ -1383,7 +1385,7 @@
      }
  
      public void func_70012_b(double p_70012_1_, double p_70012_3_, double p_70012_5_, float p_70012_7_, float p_70012_8_)
-@@ -1555,33 +1701,33 @@
+@@ -1555,33 +1703,33 @@
                  double d1 = p_70108_1_.field_70161_v - this.field_70161_v;
                  double d2 = MathHelper.func_76132_a(d0, d1);
  
@@ -1431,7 +1433,7 @@
                      }
                  }
              }
-@@ -1630,10 +1776,10 @@
+@@ -1630,10 +1778,10 @@
  
      protected final Vec3d func_174806_f(float p_174806_1_, float p_174806_2_)
      {
@@ -1446,7 +1448,7 @@
          return new Vec3d((double)(f1 * f2), (double)f3, (double)(f * f2));
      }
  
-@@ -1697,10 +1843,10 @@
+@@ -1697,10 +1845,10 @@
  
          if (Double.isNaN(d0))
          {
@@ -1459,7 +1461,7 @@
          return p_70112_1_ < d0 * d0;
      }
  
-@@ -1740,7 +1886,6 @@
+@@ -1740,7 +1888,6 @@
      {
          p_190533_0_.func_188258_a(FixTypes.ENTITY, new IDataWalker()
          {
@@ -1467,7 +1469,7 @@
              public NBTTagCompound func_188266_a(IDataFixer p_188266_1_, NBTTagCompound p_188266_2_, int p_188266_3_)
              {
                  if (p_188266_2_.func_150297_b("Passengers", 9))
-@@ -1764,6 +1909,16 @@
+@@ -1764,6 +1911,16 @@
          {
              p_189511_1_.func_74782_a("Pos", this.func_70087_a(this.field_70165_t, this.field_70163_u, this.field_70161_v));
              p_189511_1_.func_74782_a("Motion", this.func_70087_a(this.field_70159_w, this.field_70181_x, this.field_70179_y));
@@ -1484,7 +1486,7 @@
              p_189511_1_.func_74782_a("Rotation", this.func_70049_a(this.field_70177_z, this.field_70125_A));
              p_189511_1_.func_74776_a("FallDistance", this.field_70143_R);
              p_189511_1_.func_74777_a("Fire", (short)this.field_190534_ay);
-@@ -1773,7 +1928,14 @@
+@@ -1773,7 +1930,14 @@
              p_189511_1_.func_74757_a("Invulnerable", this.field_83001_bt);
              p_189511_1_.func_74768_a("PortalCooldown", this.field_71088_bW);
              p_189511_1_.func_186854_a("UUID", this.func_110124_au());
@@ -1500,7 +1502,7 @@
              if (this.func_145818_k_())
              {
                  p_189511_1_.func_74778_a("CustomName", this.func_95999_t());
-@@ -1800,6 +1962,7 @@
+@@ -1800,6 +1964,7 @@
              {
                  p_189511_1_.func_74757_a("Glowing", this.field_184238_ar);
              }
@@ -1508,7 +1510,7 @@
  
              if (!this.field_184236_aF.isEmpty())
              {
-@@ -1813,6 +1976,9 @@
+@@ -1813,6 +1978,9 @@
                  p_189511_1_.func_74782_a("Tags", nbttaglist);
              }
  
@@ -1518,7 +1520,7 @@
              this.func_70014_b(p_189511_1_);
  
              if (this.func_184207_aI())
-@@ -1857,20 +2023,22 @@
+@@ -1857,20 +2025,22 @@
              this.field_70181_x = nbttaglist2.func_150309_d(1);
              this.field_70179_y = nbttaglist2.func_150309_d(2);
  
@@ -1555,7 +1557,7 @@
  
              this.field_70165_t = nbttaglist.func_150309_d(0);
              this.field_70163_u = nbttaglist.func_150309_d(1);
-@@ -1919,6 +2087,10 @@
+@@ -1919,6 +2089,10 @@
              this.func_174810_b(p_70020_1_.func_74767_n("Silent"));
              this.func_189654_d(p_70020_1_.func_74767_n("NoGravity"));
              this.func_184195_f(p_70020_1_.func_74767_n("Glowing"));
@@ -1566,7 +1568,7 @@
  
              if (p_70020_1_.func_150297_b("Tags", 9))
              {
-@@ -1938,6 +2110,50 @@
+@@ -1938,6 +2112,50 @@
              {
                  this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
              }
@@ -1617,7 +1619,7 @@
          }
          catch (Throwable throwable)
          {
-@@ -1954,7 +2170,7 @@
+@@ -1954,7 +2172,7 @@
      }
  
      @Nullable
@@ -1626,7 +1628,7 @@
      {
          ResourceLocation resourcelocation = EntityList.func_191301_a(this);
          return resourcelocation == null ? null : resourcelocation.toString();
-@@ -2011,7 +2227,10 @@
+@@ -2011,7 +2229,10 @@
          {
              EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u + (double)p_70099_2_, this.field_70161_v, p_70099_1_);
              entityitem.func_174869_p();
@@ -1638,7 +1640,7 @@
              return entityitem;
          }
      }
-@@ -2037,9 +2256,7 @@
+@@ -2037,9 +2258,7 @@
                  int k = MathHelper.func_76128_c(this.field_70165_t + (double)(((float)((i >> 1) % 2) - 0.5F) * this.field_70130_N * 0.8F));
                  int l = MathHelper.func_76128_c(this.field_70161_v + (double)(((float)((i >> 2) % 2) - 0.5F) * this.field_70130_N * 0.8F));
  
@@ -1649,7 +1651,7 @@
                  {
                      blockpos$pooledmutableblockpos.func_181079_c(k, j, l);
  
-@@ -2077,9 +2294,10 @@
+@@ -2077,9 +2296,10 @@
          }
          else
          {
@@ -1663,7 +1665,7 @@
              this.func_70071_h_();
  
              if (this.func_184218_aH())
-@@ -2104,12 +2322,12 @@
+@@ -2104,12 +2324,12 @@
  
      public double func_70033_W()
      {
@@ -1678,7 +1680,7 @@
      }
  
      public boolean func_184220_m(Entity p_184220_1_)
-@@ -2127,6 +2345,7 @@
+@@ -2127,6 +2347,7 @@
              }
          }
  
@@ -1686,7 +1688,7 @@
          if (p_184205_2_ || this.func_184228_n(p_184205_1_) && p_184205_1_.func_184219_q(this))
          {
              if (this.func_184218_aH())
-@@ -2153,7 +2372,7 @@
+@@ -2153,7 +2374,7 @@
      {
          for (int i = this.field_184244_h.size() - 1; i >= 0; --i)
          {
@@ -1695,7 +1697,7 @@
          }
      }
  
-@@ -2162,6 +2381,7 @@
+@@ -2162,6 +2383,7 @@
          if (this.field_184239_as != null)
          {
              Entity entity = this.field_184239_as;
@@ -1703,7 +1705,7 @@
              this.field_184239_as = null;
              entity.func_184225_p(this);
          }
-@@ -2175,6 +2395,29 @@
+@@ -2175,6 +2397,29 @@
          }
          else
          {
@@ -1733,7 +1735,7 @@
              if (!this.field_70170_p.field_72995_K && p_184200_1_ instanceof EntityPlayer && !(this.func_184179_bs() instanceof EntityPlayer))
              {
                  this.field_184244_h.add(0, p_184200_1_);
-@@ -2194,6 +2437,21 @@
+@@ -2194,6 +2439,21 @@
          }
          else
          {
@@ -1755,7 +1757,7 @@
              this.field_184244_h.remove(p_184225_1_);
              p_184225_1_.field_184245_j = 60;
          }
-@@ -2205,9 +2463,7 @@
+@@ -2205,9 +2465,7 @@
      }
  
      @SideOnly(Side.CLIENT)
@@ -1766,7 +1768,7 @@
      {
          this.func_70107_b(p_180426_1_, p_180426_3_, p_180426_5_);
          this.func_70101_b(p_180426_7_, p_180426_8_);
-@@ -2247,23 +2503,11 @@
+@@ -2247,23 +2505,11 @@
              {
                  this.field_181016_an = new BlockPos(p_181015_1_);
                  BlockPattern.PatternHelper blockpattern$patternhelper = Blocks.field_150427_aO.func_181089_f(this.field_70170_p, this.field_181016_an);
@@ -1794,7 +1796,7 @@
                  this.field_181018_ap = blockpattern$patternhelper.func_177669_b();
              }
  
-@@ -2276,7 +2520,7 @@
+@@ -2276,7 +2522,7 @@
          return 300;
      }
  
@@ -1803,7 +1805,7 @@
      public void func_70016_h(double p_70016_1_, double p_70016_3_, double p_70016_5_)
      {
          this.field_70159_w = p_70016_1_;
-@@ -2306,7 +2550,7 @@
+@@ -2306,7 +2552,7 @@
  
      public Iterable<ItemStack> func_184209_aF()
      {
@@ -1812,7 +1814,7 @@
      }
  
      public void func_184201_a(EntityEquipmentSlot p_184201_1_, ItemStack p_184201_2_)
-@@ -2404,43 +2648,78 @@
+@@ -2404,43 +2650,78 @@
          this.func_70052_a(5, p_82142_1_);
      }
  
@@ -1900,7 +1902,7 @@
          }
      }
  
-@@ -2470,9 +2749,9 @@
+@@ -2470,9 +2751,9 @@
                  enumfacing = EnumFacing.WEST;
              }
  
@@ -1912,7 +1914,7 @@
                  enumfacing = EnumFacing.EAST;
              }
  
-@@ -2482,15 +2761,15 @@
+@@ -2482,15 +2763,15 @@
                  enumfacing = EnumFacing.NORTH;
              }
  
@@ -1932,7 +1934,7 @@
                  enumfacing = EnumFacing.UP;
              }
  
-@@ -2500,19 +2779,19 @@
+@@ -2500,19 +2781,19 @@
              if (enumfacing.func_176740_k() == EnumFacing.Axis.X)
              {
                  this.field_70159_w = (double)(f1 * f);
@@ -1958,7 +1960,7 @@
                  this.field_70179_y = (double)(f1 * f);
              }
  
-@@ -2526,7 +2805,6 @@
+@@ -2526,7 +2807,6 @@
          this.field_70143_R = 0.0F;
      }
  
@@ -1966,7 +1968,7 @@
      public String func_70005_c_()
      {
          if (this.func_145818_k_())
-@@ -2580,19 +2858,9 @@
+@@ -2580,19 +2860,9 @@
          return false;
      }
  
@@ -1987,7 +1989,7 @@
      }
  
      public boolean func_180431_b(DamageSource p_180431_1_)
-@@ -2629,65 +2897,105 @@
+@@ -2629,65 +2899,105 @@
      @Nullable
      public Entity func_184204_a(int p_184204_1_)
      {
@@ -2133,7 +2135,7 @@
              this.field_70170_p.field_72984_F.func_76318_c("reloading");
              Entity entity = EntityList.func_191304_a(this.getClass(), worldserver1);
  
-@@ -2695,28 +3003,38 @@
+@@ -2695,28 +3005,38 @@
              {
                  entity.func_180432_n(this);
  
@@ -2177,7 +2179,7 @@
              return entity;
          }
          else
-@@ -2732,7 +3050,7 @@
+@@ -2732,7 +3052,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -2186,7 +2188,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2769,7 +3087,7 @@
+@@ -2769,7 +3089,7 @@
                  return EntityList.func_191301_a(Entity.this) + " (" + Entity.this.getClass().getCanonicalName() + ")";
              }
          });
@@ -2195,7 +2197,7 @@
          p_85029_1_.func_189529_a("Entity Name", new ICrashReportDetail<String>()
          {
              public String call() throws Exception
-@@ -2778,12 +3096,7 @@
+@@ -2778,12 +3098,7 @@
              }
          });
          p_85029_1_.func_71507_a("Entity's Exact location", String.format("%.2f, %.2f, %.2f", this.field_70165_t, this.field_70163_u, this.field_70161_v));
@@ -2209,7 +2211,7 @@
          p_85029_1_.func_71507_a("Entity's Momentum", String.format("%.2f, %.2f, %.2f", this.field_70159_w, this.field_70181_x, this.field_70179_y));
          p_85029_1_.func_189529_a("Entity's Passengers", new ICrashReportDetail<String>()
          {
-@@ -2801,18 +3114,18 @@
+@@ -2801,18 +3116,18 @@
          });
      }
  
@@ -2234,7 +2236,7 @@
      public UUID func_110124_au()
      {
          return this.field_96093_i;
-@@ -2840,7 +3153,6 @@
+@@ -2840,7 +3155,6 @@
          field_70155_l = p_184227_0_;
      }
  
@@ -2242,7 +2244,7 @@
      public ITextComponent func_145748_c_()
      {
          TextComponentString textcomponentstring = new TextComponentString(ScorePlayerTeam.func_96667_a(this.func_96124_cp(), this.func_70005_c_()));
-@@ -2851,27 +3163,32 @@
+@@ -2851,27 +3165,32 @@
  
      public void func_96094_a(String p_96094_1_)
      {
@@ -2279,7 +2281,7 @@
      }
  
      public void func_70634_a(double p_70634_1_, double p_70634_3_, double p_70634_5_)
-@@ -2881,19 +3198,19 @@
+@@ -2881,19 +3200,19 @@
          this.field_70170_p.func_72866_a(this, false);
      }
  
@@ -2304,7 +2306,7 @@
      }
  
      public EnumFacing func_184172_bi()
-@@ -2934,7 +3251,26 @@
+@@ -2934,7 +3253,26 @@
  
      public void func_174826_a(AxisAlignedBB p_174826_1_)
      {
@@ -2332,7 +2334,7 @@
      }
  
      public float func_70047_e()
-@@ -2957,48 +3293,40 @@
+@@ -2957,48 +3295,40 @@
          return false;
      }
  
@@ -2382,7 +2384,7 @@
      public void func_174794_a(CommandResultStats.Type p_174794_1_, int p_174794_2_)
      {
          if (this.field_70170_p != null && !this.field_70170_p.field_72995_K)
-@@ -3008,7 +3336,6 @@
+@@ -3008,7 +3338,6 @@
      }
  
      @Nullable
@@ -2390,7 +2392,7 @@
      public MinecraftServer func_184102_h()
      {
          return this.field_70170_p.func_73046_m();
-@@ -3044,6 +3371,218 @@
+@@ -3044,6 +3373,218 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -2609,7 +2611,7 @@
      public void func_184178_b(EntityPlayerMP p_184178_1_)
      {
      }
-@@ -3122,14 +3661,14 @@
+@@ -3122,14 +3663,14 @@
  
      public Collection<Entity> func_184182_bu()
      {
@@ -2626,7 +2628,7 @@
          this.func_184175_a(p_184180_1_, set);
          return set;
      }
-@@ -3149,11 +3688,11 @@
+@@ -3149,11 +3690,11 @@
  
      public Entity func_184208_bv()
      {
@@ -2641,7 +2643,7 @@
          }
  
          return entity;
-@@ -3212,7 +3751,7 @@
+@@ -3212,7 +3753,7 @@
          return SoundCategory.NEUTRAL;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -40,7 +40,7 @@
  import net.minecraft.nbt.NBTTagList;
  import net.minecraft.network.datasync.DataParameter;
  import net.minecraft.network.datasync.DataSerializers;
-@@ -76,22 +86,35 @@
+@@ -76,22 +86,37 @@
  import net.minecraftforge.fml.relauncher.SideOnly;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -69,11 +69,13 @@
 -    private static final DataParameter<Integer> field_184635_h = EntityDataManager.func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
 +    private static final AttributeModifier field_110157_c = (new AttributeModifier(field_110156_b, "Sprinting speed boost", 0.30000001192092896D, 2)).func_111168_a(false);
 +    public static final net.minecraft.entity.ai.attributes.IAttribute SWIM_SPEED = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "forge.swimSpeed", 1.0D, 0.0D, 1024.0D).func_111112_a(true);
-+    protected static final DataParameter<Byte> field_184621_as = EntityDataManager.<Byte>func_187226_a(EntityLivingBase.class, DataSerializers.field_187191_a);
++    public static final DataParameter<Byte> field_184621_as = EntityDataManager.<Byte>func_187226_a(EntityLivingBase.class, DataSerializers.field_187191_a); // CatRoom - protected -> public
 +    public static final DataParameter<Float> field_184632_c = EntityDataManager.<Float>func_187226_a(EntityLivingBase.class, DataSerializers.field_187193_c);
-+    private static final DataParameter<Integer> field_184633_f = EntityDataManager.<Integer>func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
-+    private static final DataParameter<Boolean> field_184634_g = EntityDataManager.<Boolean>func_187226_a(EntityLivingBase.class, DataSerializers.field_187198_h);
-+    private static final DataParameter<Integer> field_184635_h = EntityDataManager.<Integer>func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
++    // CatRoom start - private -> public
++    public static final DataParameter<Integer> field_184633_f = EntityDataManager.<Integer>func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
++    public static final DataParameter<Boolean> field_184634_g = EntityDataManager.<Boolean>func_187226_a(EntityLivingBase.class, DataSerializers.field_187198_h);
++    public static final DataParameter<Integer> field_184635_h = EntityDataManager.<Integer>func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
++    // CatRoom end - private -> public
      private AbstractAttributeMap field_110155_d;
 -    private final CombatTracker field_94063_bt = new CombatTracker(this);
 -    private final Map<Potion, PotionEffect> field_70713_bf = Maps.newHashMap();
@@ -86,7 +88,7 @@
      public boolean field_82175_bq;
      public EnumHand field_184622_au;
      public int field_110158_av;
-@@ -116,7 +139,7 @@
+@@ -116,7 +141,7 @@
      public float field_70759_as;
      public float field_70758_at;
      public float field_70747_aH = 0.02F;
@@ -95,7 +97,7 @@
      protected int field_70718_bc;
      protected boolean field_70729_aU;
      protected int field_70708_bq;
-@@ -126,7 +149,7 @@
+@@ -126,7 +151,7 @@
      protected float field_70763_ax;
      protected float field_70741_aB;
      protected int field_70744_aE;
@@ -104,7 +106,7 @@
      protected boolean field_70703_bu;
      public float field_70702_br;
      public float field_70701_bs;
-@@ -138,9 +161,9 @@
+@@ -138,9 +163,9 @@
      protected double field_184625_bj;
      protected double field_184626_bk;
      protected double field_70709_bj;
@@ -117,7 +119,7 @@
      private EntityLivingBase field_110150_bn;
      private int field_142016_bo;
      private float field_70746_aG;
-@@ -153,7 +176,21 @@
+@@ -153,7 +178,21 @@
      private DamageSource field_189750_bF;
      private long field_189751_bG;
  
@@ -140,7 +142,7 @@
      public void func_174812_G()
      {
          this.func_70097_a(DamageSource.field_76380_i, Float.MAX_VALUE);
-@@ -163,24 +200,25 @@
+@@ -163,24 +202,25 @@
      {
          super(p_i1594_1_);
          this.func_110147_ax();
@@ -175,7 +177,7 @@
      }
  
      protected void func_110147_ax()
-@@ -190,9 +228,9 @@
+@@ -190,9 +230,9 @@
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_111263_d);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188791_g);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_189429_h);
@@ -186,7 +188,7 @@
      protected void func_184231_a(double p_184231_1_, boolean p_184231_3_, IBlockState p_184231_4_, BlockPos p_184231_5_)
      {
          if (!this.func_70090_H())
-@@ -204,23 +242,21 @@
+@@ -204,23 +244,21 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -224,7 +226,7 @@
              }
          }
  
-@@ -232,7 +268,6 @@
+@@ -232,7 +270,6 @@
          return false;
      }
  
@@ -232,7 +234,7 @@
      public void func_70030_z()
      {
          this.field_70732_aI = this.field_70733_aJ;
-@@ -250,11 +285,11 @@
+@@ -250,11 +287,11 @@
              {
                  double d0 = this.field_70170_p.func_175723_af().func_177745_a(this) + this.field_70170_p.func_175723_af().func_177742_m();
  
@@ -246,7 +248,7 @@
                      {
                          this.func_70097_a(DamageSource.field_76368_d, (float)Math.max(1, MathHelper.func_76128_c(-d0 * d1)));
                      }
-@@ -273,7 +308,12 @@
+@@ -273,7 +310,12 @@
          {
              if (!this.func_70055_a(Material.field_151586_h))
              {
@@ -260,7 +262,7 @@
              }
              else
              {
-@@ -290,23 +330,14 @@
+@@ -290,23 +332,14 @@
                              float f2 = this.field_70146_Z.nextFloat() - this.field_70146_Z.nextFloat();
                              float f = this.field_70146_Z.nextFloat() - this.field_70146_Z.nextFloat();
                              float f1 = this.field_70146_Z.nextFloat() - this.field_70146_Z.nextFloat();
@@ -286,7 +288,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -364,11 +395,11 @@
+@@ -364,11 +397,11 @@
          {
              if (!this.field_70755_b.func_70089_S())
              {
@@ -300,7 +302,7 @@
              }
          }
  
-@@ -381,6 +412,16 @@
+@@ -381,6 +414,16 @@
          this.field_70170_p.field_72984_F.func_76319_b();
      }
  
@@ -317,7 +319,7 @@
      protected void func_184594_b(BlockPos p_184594_1_)
      {
          int i = EnchantmentHelper.func_185284_a(Enchantments.field_185301_j, this);
-@@ -400,38 +441,27 @@
+@@ -400,38 +443,27 @@
      {
          ++this.field_70725_aQ;
  
@@ -365,7 +367,7 @@
              }
          }
      }
-@@ -528,7 +558,6 @@
+@@ -528,7 +560,6 @@
          }
      }
  
@@ -373,7 +375,7 @@
      public void func_70014_b(NBTTagCompound p_70014_1_)
      {
          p_70014_1_.func_74776_a("Health", this.func_110143_aJ());
-@@ -574,7 +603,6 @@
+@@ -574,7 +605,6 @@
          p_70014_1_.func_74757_a("FallFlying", this.func_184613_cA());
      }
  
@@ -381,7 +383,7 @@
      public void func_70037_a(NBTTagCompound p_70037_1_)
      {
          this.func_110149_m(p_70037_1_.func_74760_g("AbsorptionAmount"));
-@@ -600,6 +628,15 @@
+@@ -600,6 +630,15 @@
              }
          }
  
@@ -397,7 +399,7 @@
          if (p_70037_1_.func_150297_b("Health", 99))
          {
              this.func_70606_j(p_70037_1_.func_74760_g("Health"));
-@@ -626,10 +663,13 @@
+@@ -626,10 +665,13 @@
          }
      }
  
@@ -412,7 +414,7 @@
          try
          {
              while (iterator.hasNext())
-@@ -639,7 +679,7 @@
+@@ -639,7 +681,7 @@
  
                  if (!potioneffect.func_76455_a(this))
                  {
@@ -421,7 +423,7 @@
                      {
                          iterator.remove();
                          this.func_70688_c(potioneffect);
-@@ -651,9 +691,20 @@
+@@ -651,9 +693,20 @@
                  }
              }
          }
@@ -444,7 +446,7 @@
  
          if (this.field_70752_e)
          {
-@@ -665,8 +716,8 @@
+@@ -665,8 +718,8 @@
              this.field_70752_e = false;
          }
  
@@ -455,7 +457,7 @@
  
          if (i > 0)
          {
-@@ -688,19 +739,10 @@
+@@ -688,19 +741,10 @@
  
              if (flag && i > 0)
              {
@@ -479,7 +481,7 @@
              }
          }
      }
-@@ -715,8 +757,10 @@
+@@ -715,8 +759,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -492,7 +494,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -736,8 +780,8 @@
+@@ -736,8 +782,8 @@
  
      protected void func_175133_bi()
      {
@@ -503,7 +505,7 @@
      }
  
      public void func_70674_bp()
-@@ -748,7 +792,10 @@
+@@ -748,7 +794,10 @@
  
              while (iterator.hasNext())
              {
@@ -515,7 +517,7 @@
                  iterator.remove();
              }
          }
-@@ -777,10 +824,15 @@
+@@ -777,10 +826,15 @@
  
      public void func_70690_d(PotionEffect p_70690_1_)
      {
@@ -531,7 +533,7 @@
              if (potioneffect == null)
              {
                  this.field_70713_bf.put(p_70690_1_.func_188419_a(), p_70690_1_);
-@@ -796,6 +848,9 @@
+@@ -796,6 +850,9 @@
  
      public boolean func_70687_e(PotionEffect p_70687_1_)
      {
@@ -541,7 +543,7 @@
          if (this.func_70668_bt() == EnumCreatureAttribute.UNDEAD)
          {
              Potion potion = p_70687_1_.func_188419_a();
-@@ -817,11 +872,16 @@
+@@ -817,11 +874,16 @@
      @Nullable
      public PotionEffect func_184596_c(@Nullable Potion p_184596_1_)
      {
@@ -558,7 +560,7 @@
          PotionEffect potioneffect = this.func_184596_c(p_184589_1_);
  
          if (potioneffect != null)
-@@ -862,29 +922,63 @@
+@@ -862,29 +924,63 @@
          }
      }
  
@@ -626,7 +628,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -909,16 +1003,17 @@
+@@ -909,16 +1005,17 @@
              {
                  float f = p_70097_2_;
  
@@ -648,7 +650,7 @@
                  {
                      this.func_184590_k(p_70097_2_);
                      p_70097_2_ = 0.0F;
-@@ -943,22 +1038,38 @@
+@@ -943,22 +1040,38 @@
                  {
                      if (p_70097_2_ <= this.field_110153_bc)
                      {
@@ -689,7 +691,7 @@
                  this.field_70739_aP = 0.0F;
                  Entity entity1 = p_70097_1_.func_76346_g();
  
-@@ -974,9 +1085,9 @@
+@@ -974,9 +1087,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -701,7 +703,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1026,17 +1137,17 @@
+@@ -1026,17 +1139,17 @@
                          double d1 = entity1.field_70165_t - this.field_70165_t;
                          double d0;
  
@@ -723,7 +725,7 @@
                      }
                  }
  
-@@ -1096,22 +1207,28 @@
+@@ -1096,22 +1209,28 @@
          else
          {
              ItemStack itemstack = null;
@@ -758,7 +760,7 @@
                  {
                      EntityPlayerMP entityplayermp = (EntityPlayerMP)this;
                      entityplayermp.func_71029_a(StatList.func_188057_b(Items.field_190929_cY));
-@@ -1125,7 +1242,8 @@
+@@ -1125,7 +1244,8 @@
                  this.field_70170_p.func_72960_a(this, (byte)35);
              }
  
@@ -768,7 +770,7 @@
          }
      }
  
-@@ -1160,9 +1278,9 @@
+@@ -1160,9 +1280,9 @@
              {
                  Vec3d vec3d1 = this.func_70676_i(1.0F);
                  Vec3d vec3d2 = vec3d.func_72444_a(new Vec3d(this.field_70165_t, this.field_70163_u, this.field_70161_v)).func_72432_b();
@@ -780,7 +782,7 @@
                  {
                      return true;
                  }
-@@ -1174,34 +1292,29 @@
+@@ -1174,34 +1294,29 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -829,7 +831,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1222,18 +1335,42 @@
+@@ -1222,18 +1337,42 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -877,7 +879,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1252,23 +1389,26 @@
+@@ -1252,23 +1391,26 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
@@ -910,7 +912,7 @@
                  }
              }
          }
-@@ -1310,26 +1450,17 @@
+@@ -1310,26 +1452,17 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -940,7 +942,7 @@
              {
                  return true;
              }
-@@ -1338,15 +1469,16 @@
+@@ -1338,15 +1471,16 @@
          return false;
      }
  
@@ -959,7 +961,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1354,23 +1486,25 @@
+@@ -1354,23 +1488,25 @@
  
          if (i > 0)
          {
@@ -989,7 +991,7 @@
      public void func_70057_ab()
      {
          this.field_70738_aO = 10;
-@@ -1396,10 +1530,8 @@
+@@ -1396,10 +1532,8 @@
      {
          if (!p_70655_1_.func_76363_c())
          {
@@ -1002,7 +1004,7 @@
          }
  
          return p_70655_2_;
-@@ -1413,7 +1545,8 @@
+@@ -1413,7 +1547,8 @@
          }
          else
          {
@@ -1012,7 +1014,7 @@
              {
                  int i = (this.func_70660_b(MobEffects.field_76429_m).func_76458_c() + 1) * 5;
                  int j = 25 - i;
-@@ -1441,34 +1574,202 @@
+@@ -1441,34 +1576,202 @@
  
      protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_)
      {
@@ -1230,7 +1232,7 @@
          }
          else if (this.field_70717_bb != null)
          {
-@@ -1487,12 +1788,12 @@
+@@ -1487,12 +1790,12 @@
  
      public final int func_85035_bI()
      {
@@ -1245,7 +1247,7 @@
      }
  
      private int func_82166_i()
-@@ -1509,6 +1810,11 @@
+@@ -1509,6 +1812,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -1257,7 +1259,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1523,14 +1829,40 @@
+@@ -1523,14 +1831,40 @@
      }
  
      @SideOnly(Side.CLIENT)
@@ -1300,7 +1302,7 @@
          {
              this.field_70721_aZ = 1.5F;
              this.field_70172_ad = this.field_70771_an;
-@@ -1540,9 +1872,7 @@
+@@ -1540,9 +1874,7 @@
  
              if (flag)
              {
@@ -1311,7 +1313,7 @@
              }
  
              DamageSource damagesource;
-@@ -1560,42 +1890,17 @@
+@@ -1560,42 +1892,17 @@
                  damagesource = DamageSource.field_76377_j;
              }
  
@@ -1356,7 +1358,7 @@
      protected void func_70076_C()
      {
          this.func_70097_a(DamageSource.field_76380_i, 4.0F);
-@@ -1633,6 +1938,7 @@
+@@ -1633,6 +1940,7 @@
          if (this.field_110155_d == null)
          {
              this.field_110155_d = new AttributeMap();
@@ -1364,7 +1366,7 @@
          }
  
          return this.field_110155_d;
-@@ -1691,15 +1997,12 @@
+@@ -1691,15 +1999,12 @@
          return !this.func_184582_a(p_190630_1_).func_190926_b();
      }
  
@@ -1380,7 +1382,7 @@
      public void func_70031_b(boolean p_70031_1_)
      {
          super.func_70031_b(p_70031_1_);
-@@ -1723,9 +2026,7 @@
+@@ -1723,9 +2028,7 @@
  
      protected float func_70647_i()
      {
@@ -1391,7 +1393,7 @@
      }
  
      protected boolean func_70610_aX()
-@@ -1746,18 +2047,11 @@
+@@ -1746,18 +2049,11 @@
              {
                  EnumFacing enumfacing = enumfacing1.func_176746_e();
                  int[][] aint1 = new int[][] {{0, 1}, {0, -1}, { -1, 1}, { -1, -1}, {1, 1}, {1, -1}, { -1, 0}, {1, 0}, {0, 1}};
@@ -1413,7 +1415,7 @@
  
                  for (int[] aint : aint1)
                  {
-@@ -1765,31 +2059,29 @@
+@@ -1765,31 +2061,29 @@
                      double d10 = (double)(enumfacing1.func_82599_e() * aint[0] + enumfacing.func_82599_e() * aint[1]);
                      double d11 = d5 + d9;
                      double d12 = d6 + d10;
@@ -1453,7 +1455,7 @@
                          d14 = d12;
                      }
                  }
-@@ -1799,7 +2091,7 @@
+@@ -1799,7 +2093,7 @@
          }
          else
          {
@@ -1462,7 +1464,7 @@
              float f;
  
              if (p_110145_1_ instanceof EntityBoat)
-@@ -1808,30 +2100,29 @@
+@@ -1808,30 +2102,29 @@
              }
              else
              {
@@ -1499,7 +1501,7 @@
      public boolean func_94059_bO()
      {
          return this.func_174833_aM();
-@@ -1853,22 +2144,23 @@
+@@ -1853,22 +2146,23 @@
  
          if (this.func_70051_ag())
          {
@@ -1526,7 +1528,7 @@
      }
  
      protected float func_189749_co()
-@@ -1886,23 +2178,23 @@
+@@ -1886,23 +2180,23 @@
                  {
                      if (this.func_184613_cA())
                      {
@@ -1556,7 +1558,7 @@
                              this.field_70181_x += d2;
                              this.field_70159_w += vec3d.field_72450_a * d2 / d6;
                              this.field_70179_y += vec3d.field_72449_c * d2 / d6;
-@@ -1910,28 +2202,28 @@
+@@ -1910,28 +2204,28 @@
  
                          if (f < 0.0F)
                          {
@@ -1594,7 +1596,7 @@
  
                              if (f5 > 0.0F)
                              {
-@@ -1942,19 +2234,19 @@
+@@ -1942,19 +2236,19 @@
  
                          if (this.field_70122_E && !this.field_70170_p.field_72995_K)
                          {
@@ -1619,7 +1621,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1974,32 +2266,27 @@
+@@ -1974,32 +2268,27 @@
  
                          if (this.field_70122_E)
                          {
@@ -1660,7 +1662,7 @@
                              }
                          }
  
-@@ -2007,37 +2294,35 @@
+@@ -2007,37 +2296,35 @@
  
                          if (this.field_70123_F && this.func_70617_f_())
                          {
@@ -1707,7 +1709,7 @@
                          this.field_70159_w *= (double)f6;
                          this.field_70179_y *= (double)f6;
                          blockpos$pooledmutableblockpos.func_185344_t();
-@@ -2048,18 +2333,18 @@
+@@ -2048,18 +2335,18 @@
                      double d4 = this.field_70163_u;
                      this.func_191958_b(p_191986_1_, p_191986_2_, p_191986_3_, 0.02F);
                      this.func_70091_d(MoverType.SELF, this.field_70159_w, this.field_70181_x, this.field_70179_y);
@@ -1732,7 +1734,7 @@
                      }
                  }
              }
-@@ -2089,17 +2374,17 @@
+@@ -2089,17 +2376,17 @@
                  this.func_191958_b(p_191986_1_, p_191986_2_, p_191986_3_, f2);
                  this.func_70091_d(MoverType.SELF, this.field_70159_w, this.field_70181_x, this.field_70179_y);
                  this.field_70159_w *= (double)f1;
@@ -1754,7 +1756,7 @@
                  }
              }
          }
-@@ -2107,7 +2392,7 @@
+@@ -2107,7 +2394,7 @@
          this.field_184618_aE = this.field_70721_aZ;
          double d5 = this.field_70165_t - this.field_70169_q;
          double d7 = this.field_70161_v - this.field_70166_s;
@@ -1763,7 +1765,7 @@
          float f10 = MathHelper.func_76133_a(d5 * d5 + d9 * d9 + d7 * d7) * 4.0F;
  
          if (f10 > 1.0F)
-@@ -2140,9 +2425,10 @@
+@@ -2140,9 +2427,10 @@
          return false;
      }
  
@@ -1775,7 +1777,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2185,9 +2471,9 @@
+@@ -2185,9 +2473,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -1788,7 +1790,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2202,12 +2488,10 @@
+@@ -2202,12 +2490,10 @@
                      switch (entityequipmentslot.func_188453_a())
                      {
                          case HAND:
@@ -1803,7 +1805,7 @@
                      }
                  }
              }
-@@ -2228,7 +2512,9 @@
+@@ -2228,7 +2514,9 @@
              }
          }
  
@@ -1813,7 +1815,7 @@
          double d0 = this.field_70165_t - this.field_70169_q;
          double d1 = this.field_70161_v - this.field_70166_s;
          float f3 = (float)(d0 * d0 + d1 * d1);
-@@ -2241,7 +2527,7 @@
+@@ -2241,7 +2529,7 @@
          {
              f = 1.0F;
              f5 = (float)Math.sqrt((double)f3) * 3.0F;
@@ -1822,7 +1824,7 @@
              float f2 = MathHelper.func_76135_e(MathHelper.func_76142_g(this.field_70177_z) - f1);
  
              if (95.0F < f2 && f2 < 265.0F)
-@@ -2321,6 +2607,7 @@
+@@ -2321,6 +2609,7 @@
          {
              this.field_184629_bo = 0;
          }
@@ -1830,7 +1832,7 @@
      }
  
      protected float func_110146_f(float p_110146_1_, float p_110146_2_)
-@@ -2376,28 +2663,28 @@
+@@ -2376,28 +2665,28 @@
          }
          else if (!this.func_70613_aW())
          {
@@ -1878,7 +1880,7 @@
          if (this.func_70610_aX())
          {
              this.field_70703_bu = false;
-@@ -2411,6 +2698,7 @@
+@@ -2411,6 +2700,7 @@
              this.func_70626_be();
              this.field_70170_p.field_72984_F.func_76319_b();
          }
@@ -1886,7 +1888,7 @@
  
          this.field_70170_p.field_72984_F.func_76319_b();
          this.field_70170_p.field_72984_F.func_76320_a("jump");
-@@ -2442,10 +2730,14 @@
+@@ -2442,10 +2732,14 @@
          this.field_191988_bg *= 0.98F;
          this.field_70704_bt *= 0.9F;
          this.func_184616_r();
@@ -1901,7 +1903,7 @@
          this.field_70170_p.field_72984_F.func_76319_b();
      }
  
-@@ -2478,7 +2770,8 @@
+@@ -2478,7 +2772,8 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
@@ -1911,7 +1913,7 @@
          }
      }
  
-@@ -2500,7 +2793,7 @@
+@@ -2500,7 +2795,7 @@
  
                  for (int k = 0; k < list.size(); ++k)
                  {
@@ -1920,7 +1922,7 @@
                      {
                          ++j;
                      }
-@@ -2512,9 +2805,13 @@
+@@ -2512,9 +2807,13 @@
                  }
              }
  
@@ -1935,7 +1937,7 @@
                  this.func_82167_n(entity);
              }
          }
-@@ -2525,7 +2822,6 @@
+@@ -2525,7 +2824,6 @@
          p_82167_1_.func_70108_f(this);
      }
  
@@ -1943,7 +1945,7 @@
      public void func_184210_p()
      {
          Entity entity = this.func_184187_bx();
-@@ -2537,7 +2833,6 @@
+@@ -2537,7 +2835,6 @@
          }
      }
  
@@ -1951,7 +1953,7 @@
      public void func_70098_U()
      {
          super.func_70098_U();
-@@ -2547,10 +2842,7 @@
+@@ -2547,10 +2844,7 @@
      }
  
      @SideOnly(Side.CLIENT)
@@ -1963,7 +1965,7 @@
      {
          this.field_184623_bh = p_180426_1_;
          this.field_184624_bi = p_180426_3_;
-@@ -2580,18 +2872,9 @@
+@@ -2580,18 +2874,9 @@
  
      public boolean func_70685_l(Entity p_70685_1_)
      {
@@ -1983,7 +1985,7 @@
      public Vec3d func_70676_i(float p_70676_1_)
      {
          if (p_70676_1_ == 1.0F)
-@@ -2624,37 +2907,31 @@
+@@ -2624,37 +2909,31 @@
          return !this.field_70170_p.field_72995_K;
      }
  
@@ -2023,7 +2025,7 @@
      public void func_181013_g(float p_181013_1_)
      {
          this.field_70761_aq = p_181013_1_;
-@@ -2688,16 +2965,50 @@
+@@ -2688,16 +2967,50 @@
          this.field_70752_e = true;
      }
  
@@ -2076,7 +2078,7 @@
      }
  
      protected void func_184608_ct()
-@@ -2705,15 +3016,23 @@
+@@ -2705,15 +3018,23 @@
          if (this.func_184587_cr())
          {
              ItemStack itemstack = this.func_184586_b(this.func_184600_cs());
@@ -2101,7 +2103,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2731,8 +3050,10 @@
+@@ -2731,8 +3052,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -2113,7 +2115,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2743,12 +3064,11 @@
+@@ -2743,12 +3066,11 @@
                      i |= 2;
                  }
  
@@ -2127,7 +2129,7 @@
      public void func_184206_a(DataParameter<?> p_184206_1_)
      {
          super.func_184206_a(p_184206_1_);
-@@ -2785,51 +3105,26 @@
+@@ -2785,51 +3107,26 @@
              {
                  for (int i = 0; i < p_184584_2_; ++i)
                  {
@@ -2189,7 +2191,7 @@
              }
          }
      }
-@@ -2839,7 +3134,27 @@
+@@ -2839,7 +3136,27 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -2218,7 +2220,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2863,7 +3178,8 @@
+@@ -2863,7 +3180,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -2228,7 +2230,7 @@
          }
  
          this.func_184602_cy();
-@@ -2873,7 +3189,7 @@
+@@ -2873,7 +3191,7 @@
      {
          if (!this.field_70170_p.field_72995_K)
          {
@@ -2237,7 +2239,7 @@
          }
  
          this.field_184627_bm = ItemStack.field_190927_a;
-@@ -2947,11 +3263,14 @@
+@@ -2947,11 +3265,14 @@
  
              if (flag1)
              {
@@ -2257,7 +2259,7 @@
                  }
              }
          }
-@@ -2967,13 +3286,13 @@
+@@ -2967,13 +3288,13 @@
  
              for (int j = 0; j < 128; ++j)
              {
@@ -2274,7 +2276,7 @@
                  world.func_175688_a(EnumParticleTypes.PORTAL, d3, d4, d5, (double)f, (double)f1, (double)f2);
              }
  
-@@ -2986,11 +3305,41 @@
+@@ -2986,11 +3307,41 @@
          }
      }
  
@@ -2316,7 +2318,7 @@
      public boolean func_190631_cK()
      {
          return true;
-@@ -2999,5 +3348,31 @@
+@@ -2999,5 +3350,31 @@
      @SideOnly(Side.CLIENT)
      public void func_191987_a(BlockPos p_191987_1_, boolean p_191987_2_)
      {

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -7,7 +7,7 @@
  import com.google.common.base.Predicate;
  import com.google.common.collect.Lists;
  import com.mojang.authlib.GameProfile;
-@@ -92,21 +93,37 @@
+@@ -92,21 +93,41 @@
  import net.minecraft.world.WorldServer;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
@@ -38,12 +38,16 @@
 +    public float eyeHeight = this.getDefaultEyeHeight();
 +    public static final net.minecraft.entity.ai.attributes.IAttribute REACH_DISTANCE = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "generic.reachDistance", 5.0D, 0.0D, 1024.0D).func_111112_a(true);
 +
-+    private static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
-+    private static final DataParameter<Integer> field_184830_b = EntityDataManager.<Integer>func_187226_a(EntityPlayer.class, DataSerializers.field_187192_b);
-+    protected static final DataParameter<Byte> field_184827_bp = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
-+    protected static final DataParameter<Byte> field_184828_bq = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
-+    protected static final DataParameter<NBTTagCompound> field_192032_bt = EntityDataManager.<NBTTagCompound>func_187226_a(EntityPlayer.class, DataSerializers.field_192734_n);
-+    protected static final DataParameter<NBTTagCompound> field_192033_bu = EntityDataManager.<NBTTagCompound>func_187226_a(EntityPlayer.class, DataSerializers.field_192734_n);
++    // CatRoom start - private -> public
++    public static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
++    public static final DataParameter<Integer> field_184830_b = EntityDataManager.<Integer>func_187226_a(EntityPlayer.class, DataSerializers.field_187192_b);
++    // CatRoom end - private -> public
++    // CatRoom start - protected -> public
++    public static final DataParameter<Byte> field_184827_bp = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
++    public static final DataParameter<Byte> field_184828_bq = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
++    public static final DataParameter<NBTTagCompound> field_192032_bt = EntityDataManager.<NBTTagCompound>func_187226_a(EntityPlayer.class, DataSerializers.field_192734_n);
++    public static final DataParameter<NBTTagCompound> field_192033_bu = EntityDataManager.<NBTTagCompound>func_187226_a(EntityPlayer.class, DataSerializers.field_192734_n);
++    // CatRoom end
      public InventoryPlayer field_71071_by = new InventoryPlayer(this);
 -    protected InventoryEnderChest field_71078_a = new InventoryEnderChest();
 +    protected InventoryEnderChest field_71078_a = new InventoryEnderChest(this); // CraftBukkit - add "this" to constructor
@@ -54,7 +58,7 @@
      protected int field_71101_bC;
      public float field_71107_bF;
      public float field_71109_bG;
-@@ -117,9 +134,9 @@
+@@ -117,9 +138,9 @@
      public double field_71094_bP;
      public double field_71095_bQ;
      public double field_71085_bR;
@@ -66,7 +70,7 @@
      public float field_71079_bU;
      @SideOnly(Side.CLIENT)
      public float field_71082_cx;
-@@ -141,6 +158,10 @@
+@@ -141,6 +162,10 @@
      @Nullable
      public EntityFishHook field_71104_cf;
  
@@ -77,7 +81,7 @@
      protected CooldownTracker func_184815_l()
      {
          return new CooldownTracker();
-@@ -154,35 +175,37 @@
+@@ -154,35 +179,37 @@
          this.field_71069_bz = new ContainerPlayer(this.field_71071_by, !p_i45324_1_.field_72995_K, this);
          this.field_71070_bA = this.field_71069_bz;
          BlockPos blockpos = p_i45324_1_.func_175694_M();
@@ -103,8 +107,7 @@
      }
  
 -    @Override
--    protected void func_70088_a()
-+    public void func_70088_a() // CatRoom - protected -> public
+     protected void func_70088_a()
      {
          super.func_70088_a();
 -        this.field_70180_af.func_187214_a(field_184829_a, 0.0F);
@@ -126,7 +129,7 @@
          this.field_70145_X = this.func_175149_v();
  
          if (this.func_175149_v())
-@@ -210,7 +233,7 @@
+@@ -210,7 +237,7 @@
                  {
                      this.func_70999_a(true, true, false);
                  }
@@ -135,7 +138,7 @@
                  {
                      this.func_70999_a(false, true, true);
                  }
-@@ -258,8 +281,8 @@
+@@ -258,8 +285,8 @@
          }
  
          int i = 29999999;
@@ -146,7 +149,7 @@
  
          if (d0 != this.field_70165_t || d1 != this.field_70161_v)
          {
-@@ -291,47 +314,47 @@
+@@ -291,47 +318,47 @@
          double d0 = this.field_70165_t - this.field_71094_bP;
          double d1 = this.field_70163_u - this.field_71095_bQ;
          double d2 = this.field_70161_v - this.field_71085_bR;
@@ -235,7 +238,7 @@
      }
  
      protected void func_184808_cD()
-@@ -363,67 +386,52 @@
+@@ -363,67 +390,52 @@
          if (f != this.field_70130_N || f1 != this.field_70131_O)
          {
              AxisAlignedBB axisalignedbb = this.func_174813_aQ();
@@ -307,7 +310,7 @@
      public void func_70103_a(byte p_70103_1_)
      {
          if (p_70103_1_ == 9)
-@@ -444,7 +452,6 @@
+@@ -444,7 +456,6 @@
          }
      }
  
@@ -315,7 +318,7 @@
      protected boolean func_70610_aX()
      {
          return this.func_110143_aJ() <= 0.0F || this.func_70608_bn();
-@@ -455,7 +462,6 @@
+@@ -455,7 +466,6 @@
          this.field_71070_bA = this.field_71069_bz;
      }
  
@@ -323,7 +326,7 @@
      public void func_70098_U()
      {
          if (!this.field_70170_p.field_72995_K && this.func_70093_af() && this.func_184218_aH())
-@@ -475,17 +481,16 @@
+@@ -475,17 +485,16 @@
              this.field_71109_bG = 0.0F;
              this.func_71015_k(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
  
@@ -343,7 +346,7 @@
      public void func_70065_x()
      {
          this.func_70105_a(0.6F, 1.8F);
-@@ -494,7 +499,6 @@
+@@ -494,7 +503,6 @@
          this.field_70725_aQ = 0;
      }
  
@@ -351,7 +354,7 @@
      protected void func_70626_be()
      {
          super.func_70626_be();
-@@ -502,7 +506,6 @@
+@@ -502,7 +510,6 @@
          this.field_70759_as = this.field_70177_z;
      }
  
@@ -359,7 +362,7 @@
      public void func_70636_d()
      {
          if (this.field_71101_bC > 0)
-@@ -514,7 +517,8 @@
+@@ -514,7 +521,8 @@
          {
              if (this.func_110143_aJ() < this.func_110138_aP() && this.field_70173_aa % 20 == 0)
              {
@@ -369,7 +372,7 @@
              }
  
              if (this.field_71100_bB.func_75121_c() && this.field_70173_aa % 10 == 0)
-@@ -537,12 +541,12 @@
+@@ -537,12 +545,12 @@
  
          if (this.func_70051_ag())
          {
@@ -384,7 +387,7 @@
  
          if (f > 0.1F)
          {
-@@ -568,11 +572,11 @@
+@@ -568,11 +576,11 @@
  
              if (this.func_184218_aH() && !this.func_184187_bx().field_70128_L)
              {
@@ -398,7 +401,7 @@
              }
  
              List<Entity> list = this.field_70170_p.func_72839_b(this, axisalignedbb);
-@@ -591,8 +595,7 @@
+@@ -591,8 +599,7 @@
          this.func_192028_j(this.func_192023_dk());
          this.func_192028_j(this.func_192025_dl());
  
@@ -408,7 +411,7 @@
          {
              this.func_192030_dh();
          }
-@@ -618,27 +621,30 @@
+@@ -618,27 +625,30 @@
  
      public int func_71037_bA()
      {
@@ -444,7 +447,7 @@
  
          if ("Notch".equals(this.func_70005_c_()))
          {
-@@ -651,15 +657,18 @@
+@@ -651,15 +661,18 @@
              this.field_71071_by.func_70436_m();
          }
  
@@ -467,7 +470,7 @@
          }
  
          this.func_71029_a(StatList.field_188069_A);
-@@ -681,7 +690,6 @@
+@@ -681,7 +694,6 @@
          }
      }
  
@@ -475,7 +478,7 @@
      protected SoundEvent func_184601_bQ(DamageSource p_184601_1_)
      {
          if (p_184601_1_ == DamageSource.field_76370_b)
-@@ -694,7 +702,6 @@
+@@ -694,7 +706,6 @@
          }
      }
  
@@ -483,7 +486,7 @@
      protected SoundEvent func_184615_bR()
      {
          return SoundEvents.field_187798_ea;
-@@ -703,21 +710,25 @@
+@@ -703,21 +714,25 @@
      @Nullable
      public EntityItem func_71040_bB(boolean p_71040_1_)
      {
@@ -519,7 +522,7 @@
      }
  
      @Nullable
-@@ -729,7 +740,7 @@
+@@ -729,7 +744,7 @@
          }
          else
          {
@@ -528,7 +531,7 @@
              EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, d0, this.field_70161_v, p_146097_1_);
              entityitem.func_174867_a(40);
  
-@@ -741,32 +752,48 @@
+@@ -741,32 +756,48 @@
              if (p_146097_2_)
              {
                  float f = this.field_70146_Z.nextFloat() * 0.5F;
@@ -591,7 +594,7 @@
              ItemStack itemstack = this.func_184816_a(entityitem);
  
              if (p_146097_3_)
-@@ -785,13 +812,21 @@
+@@ -785,13 +816,21 @@
  
      public ItemStack func_184816_a(EntityItem p_184816_1_)
      {
@@ -614,7 +617,7 @@
  
          if (f > 1.0F)
          {
-@@ -842,21 +877,19 @@
+@@ -842,21 +881,19 @@
              f /= 5.0F;
          }
  
@@ -640,7 +643,7 @@
              public NBTTagCompound func_188266_a(IDataFixer p_188266_1_, NBTTagCompound p_188266_2_, int p_188266_3_)
              {
                  DataFixesManager.func_188278_b(p_188266_1_, p_188266_2_, p_188266_3_, "Inventory");
-@@ -864,25 +897,19 @@
+@@ -864,25 +901,19 @@
  
                  if (p_188266_2_.func_150297_b("ShoulderEntityLeft", 10))
                  {
@@ -669,7 +672,7 @@
      public void func_70037_a(NBTTagCompound p_70037_1_)
      {
          super.func_70037_a(p_70037_1_);
-@@ -910,12 +937,28 @@
+@@ -910,12 +941,28 @@
              this.func_70999_a(true, true, false);
          }
  
@@ -698,7 +701,7 @@
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
  
-@@ -936,7 +979,6 @@
+@@ -936,7 +983,6 @@
          }
      }
  
@@ -706,7 +709,7 @@
      public void func_70014_b(NBTTagCompound p_70014_1_)
      {
          super.func_70014_b(p_70014_1_);
-@@ -950,6 +992,7 @@
+@@ -950,6 +996,7 @@
          p_70014_1_.func_74768_a("XpTotal", this.field_71067_cb);
          p_70014_1_.func_74768_a("XpSeed", this.field_175152_f);
          p_70014_1_.func_74768_a("Score", this.func_71037_bA());
@@ -714,7 +717,7 @@
  
          if (this.field_71077_c != null)
          {
-@@ -959,6 +1002,27 @@
+@@ -959,6 +1006,27 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
  
@@ -742,7 +745,7 @@
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -972,11 +1036,12 @@
+@@ -972,11 +1040,12 @@
          {
              p_70014_1_.func_74782_a("ShoulderEntityRight", this.func_192025_dl());
          }
@@ -756,7 +759,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1000,13 +1065,13 @@
+@@ -1000,13 +1069,13 @@
                      this.func_70999_a(true, true, false);
                  }
  
@@ -772,7 +775,7 @@
                      }
  
                      if (this.field_70170_p.func_175659_aa() == EnumDifficulty.EASY)
-@@ -1020,17 +1085,23 @@
+@@ -1020,17 +1089,23 @@
                      }
                  }
  
@@ -799,7 +802,7 @@
          {
              this.func_190777_m(true);
          }
-@@ -1038,36 +1109,48 @@
+@@ -1038,36 +1113,48 @@
  
      public boolean func_96122_a(EntityPlayer p_96122_1_)
      {
@@ -862,7 +865,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1099,29 +1182,44 @@
+@@ -1099,29 +1186,44 @@
          return (float)i / (float)this.field_71071_by.field_70460_b.size();
      }
  
@@ -920,7 +923,7 @@
      }
  
      public void func_175141_a(TileEntitySign p_175141_1_)
-@@ -1173,6 +1271,8 @@
+@@ -1173,6 +1275,8 @@
          }
          else
          {
@@ -929,7 +932,7 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1182,7 +1282,10 @@
+@@ -1182,7 +1286,10 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
@@ -941,7 +944,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1198,6 +1301,7 @@
+@@ -1198,6 +1305,7 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
@@ -949,7 +952,7 @@
                              this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                          }
  
-@@ -1210,13 +1314,11 @@
+@@ -1210,13 +1318,11 @@
          }
      }
  
@@ -964,7 +967,7 @@
      public void func_184210_p()
      {
          super.func_184210_p();
-@@ -1225,6 +1327,7 @@
+@@ -1225,6 +1331,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -972,7 +975,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1242,8 +1345,8 @@
+@@ -1242,8 +1349,8 @@
                  }
  
                  float f2 = this.func_184825_o(0.5F);
@@ -983,7 +986,7 @@
                  this.func_184821_cY();
  
                  if (f > 0.0F || f1 > 0.0F)
-@@ -1251,34 +1354,26 @@
+@@ -1251,34 +1358,26 @@
                      boolean flag = f2 > 0.9F;
                      boolean flag1 = false;
                      int i = 0;
@@ -1025,7 +1028,7 @@
                      boolean flag3 = false;
                      double d0 = (double)(this.field_70140_Q - this.field_70141_P);
  
-@@ -1302,8 +1397,18 @@
+@@ -1302,8 +1401,18 @@
  
                          if (j > 0 && !p_71059_1_.func_70027_ad())
                          {
@@ -1046,7 +1049,7 @@
                          }
                      }
  
-@@ -1318,25 +1423,15 @@
+@@ -1318,25 +1427,15 @@
                          {
                              if (p_71059_1_ instanceof EntityLivingBase)
                              {
@@ -1076,7 +1079,7 @@
                              this.func_70031_b(false);
                          }
  
-@@ -1344,46 +1439,50 @@
+@@ -1344,46 +1443,50 @@
                          {
                              float f3 = 1.0F + EnchantmentHelper.func_191527_a(this) * f;
  
@@ -1154,7 +1157,7 @@
                              this.func_71009_b(p_71059_1_);
                          }
  
-@@ -1391,17 +1490,11 @@
+@@ -1391,17 +1494,11 @@
                          {
                              if (flag)
                              {
@@ -1174,7 +1177,7 @@
                              }
                          }
  
-@@ -1433,10 +1526,12 @@
+@@ -1433,10 +1530,12 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -1187,7 +1190,7 @@
                                  this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                              }
                          }
-@@ -1448,40 +1543,40 @@
+@@ -1448,40 +1547,40 @@
  
                              if (j > 0)
                              {
@@ -1247,7 +1250,7 @@
                      }
                  }
              }
-@@ -1499,7 +1594,7 @@
+@@ -1499,7 +1598,7 @@
  
          if (this.field_70146_Z.nextFloat() < f)
          {
@@ -1256,7 +1259,7 @@
              this.func_184602_cy();
              this.field_70170_p.func_72960_a(this, (byte)30);
          }
-@@ -1515,23 +1610,12 @@
+@@ -1515,23 +1614,12 @@
  
      public void func_184810_cG()
      {
@@ -1283,7 +1286,7 @@
          }
      }
  
-@@ -1540,7 +1624,6 @@
+@@ -1540,7 +1628,6 @@
      {
      }
  
@@ -1291,7 +1294,7 @@
      public void func_70106_y()
      {
          super.func_70106_y();
-@@ -1552,7 +1635,6 @@
+@@ -1552,7 +1639,6 @@
          }
      }
  
@@ -1299,7 +1302,7 @@
      public boolean func_70094_T()
      {
          return !this.field_71083_bS && super.func_70094_T();
-@@ -1570,7 +1652,11 @@
+@@ -1570,7 +1656,11 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -1312,7 +1315,7 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
-@@ -1584,7 +1670,7 @@
+@@ -1584,7 +1674,7 @@
                  return EntityPlayer.SleepResult.NOT_POSSIBLE_HERE;
              }
  
@@ -1321,7 +1324,7 @@
              {
                  return EntityPlayer.SleepResult.NOT_POSSIBLE_NOW;
              }
-@@ -1594,21 +1680,9 @@
+@@ -1594,21 +1684,9 @@
                  return EntityPlayer.SleepResult.TOO_FAR_AWAY;
              }
  
@@ -1346,7 +1349,7 @@
  
              if (!list.isEmpty())
              {
-@@ -1621,35 +1695,40 @@
+@@ -1621,35 +1699,40 @@
              this.func_184210_p();
          }
  
@@ -1402,7 +1405,7 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
-@@ -1661,18 +1740,15 @@
+@@ -1661,18 +1744,15 @@
  
      private boolean func_190774_a(BlockPos p_190774_1_, EnumFacing p_190774_2_)
      {
@@ -1424,7 +1427,7 @@
          }
      }
  
-@@ -1684,24 +1760,25 @@
+@@ -1684,24 +1764,25 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -1459,7 +1462,7 @@
          }
  
          this.field_71083_bS = false;
-@@ -1711,6 +1788,23 @@
+@@ -1711,6 +1792,23 @@
              this.field_70170_p.func_72854_c();
          }
  
@@ -1483,7 +1486,7 @@
          this.field_71076_b = p_70999_1_ ? 0 : 100;
  
          if (p_70999_3_)
-@@ -1721,15 +1815,16 @@
+@@ -1721,15 +1819,16 @@
  
      private boolean func_175143_p()
      {
@@ -1503,7 +1506,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1744,16 +1839,17 @@
+@@ -1744,16 +1843,17 @@
          }
          else
          {
@@ -1524,7 +1527,7 @@
  
              switch (enumfacing)
              {
-@@ -1771,7 +1867,6 @@
+@@ -1771,7 +1871,6 @@
          return 0.0F;
      }
  
@@ -1532,7 +1535,7 @@
      public boolean func_70608_bn()
      {
          return this.field_71083_bS;
-@@ -1794,25 +1889,35 @@
+@@ -1794,25 +1893,35 @@
  
      public BlockPos func_180470_cg()
      {
@@ -1570,7 +1573,7 @@
          }
      }
  
-@@ -1841,7 +1946,6 @@
+@@ -1841,7 +1950,6 @@
      {
      }
  
@@ -1578,7 +1581,7 @@
      public void func_70664_aZ()
      {
          super.func_70664_aZ();
-@@ -1849,15 +1953,16 @@
+@@ -1849,15 +1957,16 @@
  
          if (this.func_70051_ag())
          {
@@ -1598,7 +1601,7 @@
      public void func_191986_a(float p_191986_1_, float p_191986_2_, float p_191986_3_)
      {
          double d0 = this.field_70165_t;
-@@ -1870,10 +1975,13 @@
+@@ -1870,10 +1979,13 @@
              float f = this.field_70747_aH;
              this.field_70747_aH = this.field_71075_bZ.func_75093_a() * (float)(this.func_70051_ag() ? 2 : 1);
              super.func_191986_a(p_191986_1_, p_191986_2_, p_191986_3_);
@@ -1614,7 +1617,7 @@
          }
          else
          {
-@@ -1883,7 +1991,6 @@
+@@ -1883,7 +1995,6 @@
          this.func_71000_j(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
      }
  
@@ -1622,7 +1625,7 @@
      public float func_70689_ay()
      {
          return (float)this.func_110148_a(SharedMonsterAttributes.field_111263_d).func_111126_e();
-@@ -1900,7 +2007,8 @@
+@@ -1900,7 +2011,8 @@
                  if (i > 0)
                  {
                      this.func_71064_a(StatList.field_188105_q, i);
@@ -1632,7 +1635,7 @@
                  }
              }
              else if (this.func_70090_H())
-@@ -1910,14 +2018,15 @@
+@@ -1910,14 +2022,15 @@
                  if (j > 0)
                  {
                      this.func_71064_a(StatList.field_75946_m, j);
@@ -1651,7 +1654,7 @@
                  }
              }
              else if (this.field_70122_E)
-@@ -1929,17 +2038,20 @@
+@@ -1929,17 +2042,20 @@
                      if (this.func_70051_ag())
                      {
                          this.func_71064_a(StatList.field_188102_l, k);
@@ -1675,7 +1678,7 @@
                      }
                  }
              }
-@@ -1988,21 +2100,23 @@
+@@ -1988,21 +2104,23 @@
          }
      }
  
@@ -1702,7 +1705,7 @@
      protected void func_71061_d_()
      {
          if (!this.func_175149_v())
-@@ -2011,13 +2125,11 @@
+@@ -2011,13 +2129,11 @@
          }
      }
  
@@ -1716,7 +1719,7 @@
      public void func_70074_a(EntityLivingBase p_70074_1_)
      {
          EntityList.EntityEggInfo entitylist$entityegginfo = EntityList.field_75627_a.get(EntityList.func_191301_a(p_70074_1_));
-@@ -2028,7 +2140,6 @@
+@@ -2028,7 +2144,6 @@
          }
      }
  
@@ -1724,7 +1727,7 @@
      public void func_70110_aj()
      {
          if (!this.field_71075_bZ.field_75100_b)
-@@ -2089,10 +2200,7 @@
+@@ -2089,10 +2204,7 @@
          if (p_82242_1_ > 0 && this.field_71068_ca % 5 == 0 && (float)this.field_82249_h < (float)this.field_70173_aa - 100.0F)
          {
              float f = this.field_71068_ca > 30 ? 1.0F : (float)this.field_71068_ca / 30.0F;
@@ -1736,7 +1739,7 @@
              this.field_82249_h = this.field_70173_aa;
          }
      }
-@@ -2111,6 +2219,7 @@
+@@ -2111,6 +2223,7 @@
  
      public void func_71020_j(float p_71020_1_)
      {
@@ -1744,7 +1747,7 @@
          if (!this.field_71075_bZ.field_75102_a)
          {
              if (!this.field_70170_p.field_72995_K)
-@@ -2158,7 +2267,6 @@
+@@ -2158,7 +2271,6 @@
          }
      }
  
@@ -1752,7 +1755,7 @@
      protected int func_70693_a(EntityPlayer p_70693_1_)
      {
          if (!this.field_70170_p.func_82736_K().func_82766_b("keepInventory") && !this.func_175149_v())
-@@ -2172,20 +2280,17 @@
+@@ -2172,20 +2284,17 @@
          }
      }
  
@@ -1773,7 +1776,7 @@
      protected boolean func_70041_e_()
      {
          return !this.field_71075_bZ.field_75100_b;
-@@ -2199,7 +2304,6 @@
+@@ -2199,7 +2308,6 @@
      {
      }
  
@@ -1781,7 +1784,7 @@
      public String func_70005_c_()
      {
          return this.field_146106_i.getName();
-@@ -2210,7 +2314,6 @@
+@@ -2210,7 +2318,6 @@
          return this.field_71078_a;
      }
  
@@ -1789,7 +1792,7 @@
      public ItemStack func_184582_a(EntityEquipmentSlot p_184582_1_)
      {
          if (p_184582_1_ == EntityEquipmentSlot.MAINHAND)
-@@ -2223,13 +2326,10 @@
+@@ -2223,13 +2330,10 @@
          }
          else
          {
@@ -1804,7 +1807,7 @@
      public void func_184201_a(EntityEquipmentSlot p_184201_1_, ItemStack p_184201_2_)
      {
          if (p_184201_1_ == EntityEquipmentSlot.MAINHAND)
-@@ -2255,13 +2355,11 @@
+@@ -2255,13 +2359,11 @@
          return this.field_71071_by.func_70441_a(p_191521_1_);
      }
  
@@ -1818,7 +1821,7 @@
      public Iterable<ItemStack> func_184193_aE()
      {
          return this.field_71071_by.field_70460_b;
-@@ -2269,19 +2367,22 @@
+@@ -2269,19 +2371,22 @@
  
      public boolean func_192027_g(NBTTagCompound p_192027_1_)
      {
@@ -1854,7 +1857,7 @@
          }
          else
          {
-@@ -2291,10 +2392,16 @@
+@@ -2291,10 +2396,16 @@
  
      protected void func_192030_dh()
      {
@@ -1875,7 +1878,7 @@
      }
  
      private void func_192026_k(@Nullable NBTTagCompound p_192026_1_)
-@@ -2308,13 +2415,29 @@
+@@ -2308,13 +2419,29 @@
                  ((EntityTameable)entity).func_184754_b(this.field_96093_i);
              }
  
@@ -1907,7 +1910,7 @@
      public boolean func_98034_c(EntityPlayer p_98034_1_)
      {
          if (!this.func_82150_aj())
-@@ -2336,7 +2459,6 @@
+@@ -2336,7 +2463,6 @@
  
      public abstract boolean func_184812_l_();
  
@@ -1915,7 +1918,7 @@
      public boolean func_96092_aw()
      {
          return !this.field_71075_bZ.field_75100_b;
-@@ -2347,44 +2469,46 @@
+@@ -2347,44 +2473,46 @@
          return this.field_70170_p.func_96441_U();
      }
  
@@ -1973,7 +1976,7 @@
      public void func_110149_m(float p_110149_1_)
      {
          if (p_110149_1_ < 0.0F)
-@@ -2392,13 +2516,12 @@
+@@ -2392,13 +2520,12 @@
              p_110149_1_ = 0.0F;
          }
  
@@ -1989,7 +1992,7 @@
      }
  
      public static UUID func_146094_a(GameProfile p_146094_0_)
-@@ -2434,16 +2557,14 @@
+@@ -2434,16 +2561,14 @@
      @SideOnly(Side.CLIENT)
      public boolean func_175148_a(EnumPlayerModelParts p_175148_1_)
      {
@@ -2007,7 +2010,7 @@
      public boolean func_174820_d(int p_174820_1_, ItemStack p_174820_2_)
      {
          if (p_174820_1_ >= 0 && p_174820_1_ < this.field_71071_by.field_70462_a.size())
-@@ -2535,40 +2656,39 @@
+@@ -2535,40 +2660,39 @@
          this.field_175153_bG = p_175150_1_;
      }
  
@@ -2055,7 +2058,7 @@
      }
  
      public float func_184825_o(float p_184825_1_)
-@@ -2586,7 +2706,6 @@
+@@ -2586,7 +2710,6 @@
          return this.field_184832_bU;
      }
  
@@ -2063,7 +2066,7 @@
      public void func_70108_f(Entity p_70108_1_)
      {
          if (!this.func_70608_bn())
-@@ -2605,6 +2724,168 @@
+@@ -2605,6 +2728,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  
@@ -2232,7 +2235,7 @@
      public static enum EnumChatVisibility
      {
          FULL(0, "options.chat.visibility.full"),
-@@ -2671,5 +2952,10 @@
+@@ -2671,5 +2956,10 @@
          TOO_FAR_AWAY,
          OTHER_PROBLEM,
          NOT_SAFE;

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -103,7 +103,8 @@
      }
  
 -    @Override
-     protected void func_70088_a()
+-    protected void func_70088_a()
++    public void func_70088_a() // CatRoom - protected -> public
      {
          super.func_70088_a();
 -        this.field_70180_af.func_187214_a(field_184829_a, 0.0F);

--- a/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
@@ -9,7 +9,7 @@
  import net.minecraft.crash.CrashReport;
  import net.minecraft.crash.CrashReportCategory;
  import net.minecraft.entity.Entity;
-@@ -24,9 +26,9 @@
+@@ -24,11 +26,11 @@
  public class EntityDataManager
  {
      private static final Logger field_190303_a = LogManager.getLogger();
@@ -17,10 +17,14 @@
 +    private static final Map < Class <? extends Entity > , Integer > field_187232_a = Maps. < Class <? extends Entity > , Integer > newHashMap();
      private final Entity field_187233_b;
 -    private final Map < Integer, EntityDataManager.DataEntry<? >> field_187234_c = Maps.newHashMap();
-+    private final Map < Integer, DataEntry<? >> field_187234_c = new Int2ObjectOpenHashMap<>(); // Paper
-     private final ReadWriteLock field_187235_d = new ReentrantReadWriteLock();
-     private boolean field_187236_e = true;
+-    private final ReadWriteLock field_187235_d = new ReentrantReadWriteLock();
+-    private boolean field_187236_e = true;
++    public final Map < Integer, DataEntry<? >> field_187234_c = new Int2ObjectOpenHashMap<>(); // Paper // CatRoom - private -> public
++    public final ReadWriteLock field_187235_d = new ReentrantReadWriteLock(); // CatRoom - private -> public
++    public boolean field_187236_e = true; // CatRoom - private -> public
      private boolean field_187237_f;
+ 
+     public EntityDataManager(Entity p_i46840_1_)
 @@ -38,7 +40,7 @@
  
      public static <T> DataParameter<T> func_187226_a(Class <? extends Entity > p_187226_0_, DataSerializer<T> p_187226_1_)

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -644,7 +644,7 @@
          }
  
          PlayerInteractionManager playerinteractionmanager;
-@@ -497,101 +742,232 @@
+@@ -497,101 +742,231 @@
          return new EntityPlayerMP(this.field_72400_f, this.field_72400_f.func_71218_a(0), p_148545_1_, playerinteractionmanager);
      }
  
@@ -779,12 +779,11 @@
 +        EntityPlayerMP entityplayermp = new EntityPlayerMP(this.mcServer, this.mcServer.getWorld(playerIn.dimension), playerIn.getGameProfile(), playerinteractionmanager);
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;
-+        // CatRoom start - Call construct event and re-gather capabilities
++        // CatRoom start - Fix CB respawn logic
 +        if (catserver.server.CatServer.getConfig().callConstructCapabilityEventOnRespawn) {
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(entityplayermp));
-+            ((Entity) entityplayermp).capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(entityplayermp);
++            catserver.server.utils.ModFixUtils.fixCBRespawnLogic(entityplayermp);
 +        }
-+        // CatRoom end - Call construct event and re-gather capabilities
++        // CatRoom end - Fix CB respawn logic
 +        org.bukkit.World fromWorld = playerIn.getBukkitEntity().getWorld();
 +        playerIn.field_71136_j = false;
 +
@@ -948,7 +947,7 @@
          return entityplayermp;
      }
  
-@@ -599,75 +975,147 @@
+@@ -599,75 +974,147 @@
      {
          GameProfile gameprofile = p_187243_1_.func_146103_bH();
          int i = this.func_152596_g(gameprofile) ? this.field_72414_i.func_187452_a(gameprofile) : 0;
@@ -1151,7 +1150,7 @@
          {
              BlockPos blockpos;
  
-@@ -693,7 +1141,7 @@
+@@ -693,7 +1140,7 @@
  
          p_82448_3_.field_72984_F.func_76319_b();
  
@@ -1160,7 +1159,7 @@
          {
              p_82448_3_.field_72984_F.func_76320_a("placing");
              d0 = (double)MathHelper.func_76125_a((int)d0, -29999872, 29999872);
-@@ -702,7 +1150,8 @@
+@@ -702,7 +1149,8 @@
              if (p_82448_1_.func_70089_S())
              {
                  p_82448_1_.func_70012_b(d0, p_82448_1_.field_70163_u, d1, p_82448_1_.field_70177_z, p_82448_1_.field_70125_A);
@@ -1170,7 +1169,7 @@
                  p_82448_4_.func_72838_d(p_82448_1_);
                  p_82448_4_.func_72866_a(p_82448_1_, false);
              }
-@@ -713,11 +1162,155 @@
+@@ -713,11 +1161,155 @@
          p_82448_1_.func_70029_a(p_82448_4_);
      }
  
@@ -1327,7 +1326,7 @@
              this.field_72408_o = 0;
          }
      }
-@@ -726,9 +1319,27 @@
+@@ -726,9 +1318,27 @@
      {
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1358,7 +1357,7 @@
  
      public void func_148537_a(Packet<?> p_148537_1_, int p_148537_2_)
      {
-@@ -795,11 +1406,11 @@
+@@ -795,11 +1405,11 @@
                  s = s + ", ";
              }
  
@@ -1372,7 +1371,7 @@
              }
          }
  
-@@ -812,7 +1423,7 @@
+@@ -812,7 +1422,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1381,7 +1380,7 @@
          }
  
          return astring;
-@@ -824,7 +1435,7 @@
+@@ -824,7 +1434,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1390,7 +1389,7 @@
          }
  
          return agameprofile;
-@@ -845,12 +1456,20 @@
+@@ -845,12 +1455,20 @@
          int i = this.field_72400_f.func_110455_j();
          this.field_72414_i.func_152687_a(new UserListOpsEntry(p_152605_1_, this.field_72400_f.func_110455_j(), this.field_72414_i.func_183026_b(p_152605_1_)));
          this.func_187245_a(this.func_177451_a(p_152605_1_.getId()), i);
@@ -1411,7 +1410,7 @@
      }
  
      private void func_187245_a(EntityPlayerMP p_187245_1_, int p_187245_2_)
-@@ -883,11 +1502,7 @@
+@@ -883,11 +1501,7 @@
  
      public boolean func_152596_g(GameProfile p_152596_1_)
      {
@@ -1424,7 +1423,7 @@
      }
  
      @Nullable
-@@ -904,19 +1519,17 @@
+@@ -904,19 +1518,17 @@
          return null;
      }
  
@@ -1451,7 +1450,7 @@
  
              if (entityplayermp != p_148543_1_ && entityplayermp.field_71093_bK == p_148543_10_)
              {
-@@ -976,25 +1589,29 @@
+@@ -976,25 +1588,29 @@
  
      public void func_72354_b(EntityPlayerMP p_72354_1_, WorldServer p_72354_2_)
      {
@@ -1488,7 +1487,7 @@
          p_72385_1_.field_71135_a.func_147359_a(new SPacketHeldItemChange(p_72385_1_.field_71071_by.field_70461_c));
      }
  
-@@ -1010,13 +1627,7 @@
+@@ -1010,13 +1626,7 @@
  
      public String[] func_72373_m()
      {
@@ -1503,7 +1502,7 @@
      }
  
      public void func_72371_a(boolean p_72371_1_)
-@@ -1026,7 +1637,7 @@
+@@ -1026,7 +1636,7 @@
  
      public List<EntityPlayerMP> func_72382_j(String p_72382_1_)
      {
@@ -1512,7 +1511,7 @@
  
          for (EntityPlayerMP entityplayermp : this.field_72404_b)
          {
-@@ -1082,9 +1693,15 @@
+@@ -1082,9 +1692,15 @@
  
      public void func_72392_r()
      {
@@ -1531,7 +1530,7 @@
          }
      }
  
-@@ -1092,7 +1709,10 @@
+@@ -1092,7 +1708,10 @@
      {
          this.field_72400_f.func_145747_a(p_148544_1_);
          ChatType chattype = p_148544_2_ ? ChatType.SYSTEM : ChatType.CHAT;
@@ -1543,7 +1542,7 @@
      }
  
      public void func_148539_a(ITextComponent p_148539_1_)
-@@ -1100,10 +1720,11 @@
+@@ -1100,10 +1719,11 @@
          this.func_148544_a(p_148539_1_, true);
      }
  
@@ -1556,7 +1555,7 @@
  
          if (statisticsmanagerserver == null)
          {
-@@ -1128,6 +1749,8 @@
+@@ -1128,6 +1748,8 @@
          return statisticsmanagerserver;
      }
  
@@ -1565,7 +1564,7 @@
      public PlayerAdvancements func_192054_h(EntityPlayerMP p_192054_1_)
      {
          UUID uuid = p_192054_1_.func_110124_au();
-@@ -1151,7 +1774,7 @@
+@@ -1151,7 +1773,7 @@
  
          if (this.field_72400_f.field_71305_c != null)
          {
@@ -1574,7 +1573,7 @@
              {
                  if (worldserver != null)
                  {
-@@ -1183,5 +1806,11 @@
+@@ -1183,5 +1805,11 @@
          {
              playeradvancements.func_193766_b();
          }

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -644,7 +644,7 @@
          }
  
          PlayerInteractionManager playerinteractionmanager;
-@@ -497,101 +742,231 @@
+@@ -497,101 +742,234 @@
          return new EntityPlayerMP(this.field_72400_f, this.field_72400_f.func_71218_a(0), p_148545_1_, playerinteractionmanager);
      }
  
@@ -780,8 +780,11 @@
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;
 +        // CatRoom start - Fix CB respawn logic
-+        if (catserver.server.CatServer.getConfig().callConstructCapabilityEventOnRespawn) {
-+            catserver.server.utils.ModFixUtils.fixCBRespawnLogic(entityplayermp);
++        if (catserver.server.CatServer.getConfig().simulateVanillaRespawn) {
++            catserver.server.utils.ModFixUtils.simulateVanillaRespawn(entityplayermp);
++        }
++        if (catserver.server.CatServer.getConfig().regatherCapabilityOnRespawn) {
++            catserver.server.utils.ModFixUtils.regatherCapabilities(entityplayermp);
 +        }
 +        // CatRoom end - Fix CB respawn logic
 +        org.bukkit.World fromWorld = playerIn.getBukkitEntity().getWorld();
@@ -947,7 +950,7 @@
          return entityplayermp;
      }
  
-@@ -599,75 +974,147 @@
+@@ -599,75 +977,147 @@
      {
          GameProfile gameprofile = p_187243_1_.func_146103_bH();
          int i = this.func_152596_g(gameprofile) ? this.field_72414_i.func_187452_a(gameprofile) : 0;
@@ -1150,7 +1153,7 @@
          {
              BlockPos blockpos;
  
-@@ -693,7 +1140,7 @@
+@@ -693,7 +1143,7 @@
  
          p_82448_3_.field_72984_F.func_76319_b();
  
@@ -1159,7 +1162,7 @@
          {
              p_82448_3_.field_72984_F.func_76320_a("placing");
              d0 = (double)MathHelper.func_76125_a((int)d0, -29999872, 29999872);
-@@ -702,7 +1149,8 @@
+@@ -702,7 +1152,8 @@
              if (p_82448_1_.func_70089_S())
              {
                  p_82448_1_.func_70012_b(d0, p_82448_1_.field_70163_u, d1, p_82448_1_.field_70177_z, p_82448_1_.field_70125_A);
@@ -1169,7 +1172,7 @@
                  p_82448_4_.func_72838_d(p_82448_1_);
                  p_82448_4_.func_72866_a(p_82448_1_, false);
              }
-@@ -713,11 +1161,155 @@
+@@ -713,11 +1164,155 @@
          p_82448_1_.func_70029_a(p_82448_4_);
      }
  
@@ -1326,7 +1329,7 @@
              this.field_72408_o = 0;
          }
      }
-@@ -726,9 +1318,27 @@
+@@ -726,9 +1321,27 @@
      {
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1357,7 +1360,7 @@
  
      public void func_148537_a(Packet<?> p_148537_1_, int p_148537_2_)
      {
-@@ -795,11 +1405,11 @@
+@@ -795,11 +1408,11 @@
                  s = s + ", ";
              }
  
@@ -1371,7 +1374,7 @@
              }
          }
  
-@@ -812,7 +1422,7 @@
+@@ -812,7 +1425,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1380,7 +1383,7 @@
          }
  
          return astring;
-@@ -824,7 +1434,7 @@
+@@ -824,7 +1437,7 @@
  
          for (int i = 0; i < this.field_72404_b.size(); ++i)
          {
@@ -1389,7 +1392,7 @@
          }
  
          return agameprofile;
-@@ -845,12 +1455,20 @@
+@@ -845,12 +1458,20 @@
          int i = this.field_72400_f.func_110455_j();
          this.field_72414_i.func_152687_a(new UserListOpsEntry(p_152605_1_, this.field_72400_f.func_110455_j(), this.field_72414_i.func_183026_b(p_152605_1_)));
          this.func_187245_a(this.func_177451_a(p_152605_1_.getId()), i);
@@ -1410,7 +1413,7 @@
      }
  
      private void func_187245_a(EntityPlayerMP p_187245_1_, int p_187245_2_)
-@@ -883,11 +1501,7 @@
+@@ -883,11 +1504,7 @@
  
      public boolean func_152596_g(GameProfile p_152596_1_)
      {
@@ -1423,7 +1426,7 @@
      }
  
      @Nullable
-@@ -904,19 +1518,17 @@
+@@ -904,19 +1521,17 @@
          return null;
      }
  
@@ -1450,7 +1453,7 @@
  
              if (entityplayermp != p_148543_1_ && entityplayermp.field_71093_bK == p_148543_10_)
              {
-@@ -976,25 +1588,29 @@
+@@ -976,25 +1591,29 @@
  
      public void func_72354_b(EntityPlayerMP p_72354_1_, WorldServer p_72354_2_)
      {
@@ -1487,7 +1490,7 @@
          p_72385_1_.field_71135_a.func_147359_a(new SPacketHeldItemChange(p_72385_1_.field_71071_by.field_70461_c));
      }
  
-@@ -1010,13 +1626,7 @@
+@@ -1010,13 +1629,7 @@
  
      public String[] func_72373_m()
      {
@@ -1502,7 +1505,7 @@
      }
  
      public void func_72371_a(boolean p_72371_1_)
-@@ -1026,7 +1636,7 @@
+@@ -1026,7 +1639,7 @@
  
      public List<EntityPlayerMP> func_72382_j(String p_72382_1_)
      {
@@ -1511,7 +1514,7 @@
  
          for (EntityPlayerMP entityplayermp : this.field_72404_b)
          {
-@@ -1082,9 +1692,15 @@
+@@ -1082,9 +1695,15 @@
  
      public void func_72392_r()
      {
@@ -1530,7 +1533,7 @@
          }
      }
  
-@@ -1092,7 +1708,10 @@
+@@ -1092,7 +1711,10 @@
      {
          this.field_72400_f.func_145747_a(p_148544_1_);
          ChatType chattype = p_148544_2_ ? ChatType.SYSTEM : ChatType.CHAT;
@@ -1542,7 +1545,7 @@
      }
  
      public void func_148539_a(ITextComponent p_148539_1_)
-@@ -1100,10 +1719,11 @@
+@@ -1100,10 +1722,11 @@
          this.func_148544_a(p_148539_1_, true);
      }
  
@@ -1555,7 +1558,7 @@
  
          if (statisticsmanagerserver == null)
          {
-@@ -1128,6 +1748,8 @@
+@@ -1128,6 +1751,8 @@
          return statisticsmanagerserver;
      }
  
@@ -1564,7 +1567,7 @@
      public PlayerAdvancements func_192054_h(EntityPlayerMP p_192054_1_)
      {
          UUID uuid = p_192054_1_.func_110124_au();
-@@ -1151,7 +1773,7 @@
+@@ -1151,7 +1776,7 @@
  
          if (this.field_72400_f.field_71305_c != null)
          {
@@ -1573,7 +1576,7 @@
              {
                  if (worldserver != null)
                  {
-@@ -1183,5 +1805,11 @@
+@@ -1183,5 +1808,11 @@
          {
              playeradvancements.func_193766_b();
          }

--- a/patches/minecraft/net/minecraft/world/Explosion.java.patch
+++ b/patches/minecraft/net/minecraft/world/Explosion.java.patch
@@ -37,7 +37,7 @@
 -    private final List<BlockPos> field_77281_g = Lists.newArrayList();
 -    private final Map<EntityPlayer, Vec3d> field_77288_k = Maps.newHashMap();
 +    public final Entity field_77283_e;
-+    public float field_77280_f; // CatRoom - private final -> public
++    public final float field_77280_f; // CatRoom - private -> public
 +    private final List<BlockPos> field_77281_g;
 +    private final Map<EntityPlayer, Vec3d> field_77288_k;
 +    private final Vec3d position;

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -62,7 +62,8 @@ public class CatServerConfig {
     public boolean cachePlayerProfileResult = false;
     public int playerProfileResultCacheMinutes = 1440;
 
-    public boolean callConstructCapabilityEventOnRespawn = false;
+    public boolean regatherCapabilityOnRespawn = false;
+    public boolean simulateVanillaRespawn = false;
     public boolean bridgeForgeExplosionEventToBukkit = false;
 
     public boolean enableAffinity = false;
@@ -117,7 +118,8 @@ public class CatServerConfig {
         cachePlayerProfileResult = getOrWriteBooleanConfig("network.profile.cachePlayerProfileResult", cachePlayerProfileResult);
         playerProfileResultCacheMinutes = getOrWriteIntConfig("network.profile.playerProfileResultCacheMinutes", playerProfileResultCacheMinutes);
         // compatibility
-        callConstructCapabilityEventOnRespawn = getOrWriteBooleanConfig("compatibility.callConstructCapabilityEventOnRespawn", callConstructCapabilityEventOnRespawn);
+        regatherCapabilityOnRespawn = getOrWriteBooleanConfig("compatibility.regatherCapabilityOnRespawn", regatherCapabilityOnRespawn);
+        simulateVanillaRespawn = getOrWriteBooleanConfig("compatibility.simulateVanillaRespawn", simulateVanillaRespawn);
         bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("compatibility.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
         // general
         disableUpdateGameProfile = getOrWriteBooleanConfig("disableUpdateGameProfile", disableUpdateGameProfile);

--- a/src/main/java/catserver/server/utils/ModFixUtils.java
+++ b/src/main/java/catserver/server/utils/ModFixUtils.java
@@ -33,7 +33,7 @@ public class ModFixUtils {
         }
     }
 
-    @SuppressWarnings("unused") // Used by ModCompatibleTransformer
+    @SuppressWarnings("unused") // Used by ModsCompatibleTransformer
     public static void hookFirstAidHealthUpdate(EntityPlayer player, DataParameter key, Object value) {
         if (key.equals(EntityPlayer.HEALTH)) {
             float health = (float)value;
@@ -89,8 +89,8 @@ public class ModFixUtils {
         // Entity
         dataManager.register(Entity.FLAGS, capturedFlags);
         dataManager.register(Entity.AIR, capturedAirTicks);
-        dataManager.register(Entity.CUSTOM_NAME_VISIBLE, capturedCustomNameVisible);
         dataManager.register(Entity.CUSTOM_NAME, capturedCustomName);
+        dataManager.register(Entity.CUSTOM_NAME_VISIBLE, capturedCustomNameVisible);
         dataManager.register(Entity.SILENT, capturedSilent);
         dataManager.register(Entity.NO_GRAVITY, capturedNoGravity);
         // EntityLivingBase

--- a/src/main/java/catserver/server/utils/ModFixUtils.java
+++ b/src/main/java/catserver/server/utils/ModFixUtils.java
@@ -52,7 +52,7 @@ public class ModFixUtils {
         }
     }
 
-    public static void fixCBRespawnLogic(EntityPlayerMP playerIn) {
+    public static void simulateVanillaRespawn(EntityPlayerMP playerIn) {
         final EntityDataManager dataManager = playerIn.getDataManager();
         // Capture vanilla values
         // Entity
@@ -108,6 +108,9 @@ public class ModFixUtils {
         dataManager.register(EntityPlayer.RIGHT_SHOULDER_ENTITY, capturedRightShoulder);
 
         MinecraftForge.EVENT_BUS.post(new EntityEvent.EntityConstructing(playerIn));
+    }
+
+    public static void regatherCapabilities(EntityPlayerMP playerIn) {
         ((Entity) playerIn).capabilities = ForgeEventFactory.gatherCapabilities(playerIn);
     }
 }

--- a/src/main/java/catserver/server/utils/ModFixUtils.java
+++ b/src/main/java/catserver/server/utils/ModFixUtils.java
@@ -1,11 +1,15 @@
 package catserver.server.utils;
 
 import catserver.server.CatServer;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.fml.common.Loader;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 
@@ -26,6 +30,7 @@ public class ModFixUtils {
         }
     }
 
+    @SuppressWarnings("unused") // Used by ModCompatibleTransformer
     public static void hookFirstAidHealthUpdate(EntityPlayer player, DataParameter key, Object value) {
         if (key.equals(EntityPlayer.HEALTH)) {
             float health = (float)value;
@@ -42,5 +47,28 @@ public class ModFixUtils {
                 }
             }
         }
+    }
+
+    public static void fixCBRespawnLogic(EntityPlayerMP playerIn) {
+        try {
+            playerIn.getDataManager().lock.writeLock().lock();
+            playerIn.getDataManager().entries.clear();
+        } finally {
+            playerIn.getDataManager().lock.writeLock().unlock();
+        }
+        playerIn.getDataManager().empty = true;
+        playerIn.getDataManager().setClean();
+        // [VanillaCopy] Entity data params from Entity#<init>
+        playerIn.getDataManager().register(Entity.FLAGS, Byte.valueOf((byte)0));
+        playerIn.getDataManager().register(Entity.AIR, Integer.valueOf(300));
+        playerIn.getDataManager().register(Entity.CUSTOM_NAME_VISIBLE, Boolean.valueOf(false));
+        playerIn.getDataManager().register(Entity.CUSTOM_NAME, "");
+        playerIn.getDataManager().register(Entity.SILENT, Boolean.valueOf(false));
+        playerIn.getDataManager().register(Entity.NO_GRAVITY, Boolean.valueOf(false));
+
+        playerIn.entityInit();
+
+        MinecraftForge.EVENT_BUS.post(new EntityEvent.EntityConstructing(playerIn));
+        ((Entity) playerIn).capabilities = ForgeEventFactory.gatherCapabilities(playerIn);
     }
 }

--- a/src/main/java/catserver/server/utils/ModFixUtils.java
+++ b/src/main/java/catserver/server/utils/ModFixUtils.java
@@ -2,9 +2,12 @@ package catserver.server.utils;
 
 import catserver.server.CatServer;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
+import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
@@ -50,23 +53,59 @@ public class ModFixUtils {
     }
 
     public static void fixCBRespawnLogic(EntityPlayerMP playerIn) {
-        try {
-            playerIn.getDataManager().lock.writeLock().lock();
-            playerIn.getDataManager().entries.clear();
-        } finally {
-            playerIn.getDataManager().lock.writeLock().unlock();
-        }
-        playerIn.getDataManager().empty = true;
-        playerIn.getDataManager().setClean();
-        // [VanillaCopy] Entity data params from Entity#<init>
-        playerIn.getDataManager().register(Entity.FLAGS, Byte.valueOf((byte)0));
-        playerIn.getDataManager().register(Entity.AIR, Integer.valueOf(300));
-        playerIn.getDataManager().register(Entity.CUSTOM_NAME_VISIBLE, Boolean.valueOf(false));
-        playerIn.getDataManager().register(Entity.CUSTOM_NAME, "");
-        playerIn.getDataManager().register(Entity.SILENT, Boolean.valueOf(false));
-        playerIn.getDataManager().register(Entity.NO_GRAVITY, Boolean.valueOf(false));
+        final EntityDataManager dataManager = playerIn.getDataManager();
+        // Capture vanilla values
+        // Entity
+        byte capturedFlags = dataManager.get(Entity.FLAGS);
+        int capturedAirTicks = dataManager.get(Entity.AIR);
+        String capturedCustomName = dataManager.get(Entity.CUSTOM_NAME);
+        boolean capturedCustomNameVisible = dataManager.get(Entity.CUSTOM_NAME_VISIBLE);
+        boolean capturedSilent = dataManager.get(Entity.SILENT);
+        boolean capturedNoGravity = dataManager.get(Entity.NO_GRAVITY);
+        // EntityLivingBase
+        byte capturedHandStates = dataManager.get(EntityLivingBase.HAND_STATES);
+        float capturedHealth = dataManager.get(EntityLivingBase.HEALTH);
+        int capturedPotionEffects = dataManager.get(EntityLivingBase.POTION_EFFECTS);
+        boolean capturedHideParticles = dataManager.get(EntityLivingBase.HIDE_PARTICLES);
+        int capturedArrowCount = dataManager.get(EntityLivingBase.ARROW_COUNT_IN_ENTITY);
+        // EntityPlayer
+        float capturedAbsorptionAmount = dataManager.get(EntityPlayer.ABSORPTION);
+        int capturedScore = dataManager.get(EntityPlayer.PLAYER_SCORE);
+        byte capturedPlayerModelFlag = dataManager.get(EntityPlayer.PLAYER_MODEL_FLAG);
+        byte capturedMainHand = dataManager.get(EntityPlayer.MAIN_HAND);
+        NBTTagCompound capturedLeftShoulder = dataManager.get(EntityPlayer.LEFT_SHOULDER_ENTITY);
+        NBTTagCompound capturedRightShoulder = dataManager.get(EntityPlayer.RIGHT_SHOULDER_ENTITY);
 
-        playerIn.entityInit();
+        try {
+            dataManager.lock.writeLock().lock();
+            dataManager.entries.clear();
+        } finally {
+            dataManager.lock.writeLock().unlock();
+        }
+        dataManager.empty = true;
+        dataManager.setClean();
+
+        // Restore captured vanilla values
+        // Entity
+        dataManager.register(Entity.FLAGS, capturedFlags);
+        dataManager.register(Entity.AIR, capturedAirTicks);
+        dataManager.register(Entity.CUSTOM_NAME_VISIBLE, capturedCustomNameVisible);
+        dataManager.register(Entity.CUSTOM_NAME, capturedCustomName);
+        dataManager.register(Entity.SILENT, capturedSilent);
+        dataManager.register(Entity.NO_GRAVITY, capturedNoGravity);
+        // EntityLivingBase
+        dataManager.register(EntityLivingBase.HAND_STATES, capturedHandStates);
+        dataManager.register(EntityLivingBase.HEALTH, capturedHealth);
+        dataManager.register(EntityLivingBase.POTION_EFFECTS, capturedPotionEffects);
+        dataManager.register(EntityLivingBase.HIDE_PARTICLES, capturedHideParticles);
+        dataManager.register(EntityLivingBase.ARROW_COUNT_IN_ENTITY, capturedArrowCount);
+        // EntityPlayer
+        dataManager.register(EntityPlayer.ABSORPTION, capturedAbsorptionAmount);
+        dataManager.register(EntityPlayer.PLAYER_SCORE, capturedScore);
+        dataManager.register(EntityPlayer.PLAYER_MODEL_FLAG, capturedPlayerModelFlag);
+        dataManager.register(EntityPlayer.MAIN_HAND, capturedMainHand);
+        dataManager.register(EntityPlayer.LEFT_SHOULDER_ENTITY, capturedLeftShoulder);
+        dataManager.register(EntityPlayer.RIGHT_SHOULDER_ENTITY, capturedRightShoulder);
 
         MinecraftForge.EVENT_BUS.post(new EntityEvent.EntityConstructing(playerIn));
         ((Entity) playerIn).capabilities = ForgeEventFactory.gatherCapabilities(playerIn);


### PR DESCRIPTION
This pull request attempts to **simulate** vanilla respawn logic by calling methods originally called in constructors, as CraftBukkit respawn logic reuses player instance instead of creating a new one.

Some mods re-register DataParameter on ConstructEvent, the previous fix will cause IllegalStateException issues if mods do not check the param has been already registered.

The new fix captures all vanilla data values, clear DataManager then restore vanilla data values.

---

Download the test jars here:
- [universal-0.1.0.zip](https://github.com/user-attachments/files/18319146/universal-0.1.0.zip)
- [installer-0.1.0.zip](https://github.com/user-attachments/files/18319151/installer-0.1.0.zip)

