### PR TITLE
Placeholder class for certain mods

### DIFF
--- a/src/main/java/zone/rong/mixinbooter/Context.java
+++ b/src/main/java/zone/rong/mixinbooter/Context.java
@@ -1,0 +1,82 @@
+package zone.rong.mixinbooter;
+
+import net.minecraft.launchwrapper.Launch;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
+
+import java.util.Collection;
+
+/**
+ * This class contains loading context for callers
+ *
+ *
+ * @since 10.0
+ * @deprecated We forked Mixin.
+ * <br>New approach:
+ * Check <a href=https://github.com/CleanroomMC/Fugue/tree/master>Fugue</a>.<br>
+ * Summary:<br>
+ * If you are coremod, just call {@link org.spongepowered.asm.mixin.Mixins#addConfigurations(String...)} in loadingPluging or Tweaker, and handle shouldApply in IMixinConfigPlugin<br>
+ * If you aren't coremod:<br>
+ * Group mixins by phase, add target env in config, use @env(MOD) for mod mixins.<br>
+ * Add {"MixinConfigs": "modid.mod.mixin.json,modid.default.mixin.json"} to your jar manifest.<br>
+ * Handle shouldApply in IMixinConfigPlugin. You can call {@link net.minecraftforge.fml.common.Loader#isModLoaded(String)} for {@link org.spongepowered.asm.mixin.MixinEnvironment.Phase#MOD} mixin.<br>
+ * Recommend to group target mod name by package name. You can also get config instance from {@link org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin#injectConfig(org.spongepowered.asm.mixin.transformer.Config)}.
+ */
+// TODO: Actually implement the logic
+@Deprecated
+public final class Context {
+
+    public enum ModLoader {
+        FORGE,
+        CLEANROOM;
+    }
+
+    private final String mixinConfig;
+    private final Collection<String> presentMods;
+
+    public Context(String mixinConfigIn, Collection<String> presentModsIn) {
+        this.mixinConfig = mixinConfigIn;
+        this.presentMods = presentModsIn;
+    }
+
+    public Context(String mixinConfigIn) {
+        this(mixinConfigIn, null);
+    }
+
+    /**
+     * @return the current mod loader
+     */
+    public ModLoader modLoader() {
+        return ModLoader.CLEANROOM;
+    }
+
+    /**
+     * @return if the current environment is in-dev
+     */
+    public boolean inDev() {
+        return FMLLaunchHandler.isDeobfuscatedEnvironment();
+    }
+
+    /**
+     * @return name of the mixin config that is currently being processed
+     */
+    public String mixinConfig() {
+        return mixinConfig;
+    }
+
+    /**
+     * <p>For early contexts, the list of mods are gathered from culling the classloader
+     * for any jars that has the mcmod.info file. The mod IDs are obtained from the mcmod.info file.
+     * This means mostly, if not only coremods are queryable here,
+     * make sure to test a normal mod's existence in your mixin plugin or in the mixin itself.</p>
+     *
+     * <p>For late contexts, it comes from {@link net.minecraftforge.fml.common.Loader#getActiveModList}
+     * akin to {@link net.minecraftforge.fml.common.Loader#isModLoaded(String)}</p>
+     * @param modId to check against the list of present mods in the context
+     * @return whether the mod is present
+     */
+    public boolean isModPresent(String modId) {
+        return presentMods == null ? Loader.isModLoaded(modId) : presentMods.contains(modId);
+    }
+
+}

--- a/src/main/java/zone/rong/mixinbooter/IMixinConfigHijacker.java
+++ b/src/main/java/zone/rong/mixinbooter/IMixinConfigHijacker.java
@@ -1,0 +1,46 @@
+package zone.rong.mixinbooter;
+
+import java.util.Set;
+
+/**
+ * Hijackers are used to stop certain mixin configurations from ever being applied.
+ * Usage is similar to {@link IEarlyMixinLoader}, implement it in your coremod class.
+ * Requested by: @Desoroxxx
+ *
+ * @since 9.0
+ * @deprecated We forked Mixin.
+ * <br>New approach:
+ * Check <a href=https://github.com/CleanroomMC/Fugue/tree/master>Fugue</a>.<br>
+ * Summary:<br>
+ * If you are coremod, just call {@link org.spongepowered.asm.mixin.Mixins#addConfigurations(String...)} in loadingPlugin or Tweaker, and handle shouldApply in IMixinConfigPlugin<br>
+ * If you aren't coremod:<br>
+ * Group mixins by phase, add target env in config, use @env(MOD) for mod mixins.<br>
+ * Add {"MixinConfigs": "modid.mod.mixin.json,modid.default.mixin.json"} to your jar manifest.<br>
+ * Handle shouldApply in IMixinConfigPlugin. You can call {@link net.minecraftforge.fml.common.Loader#isModLoaded(String)} for {@link org.spongepowered.asm.mixin.MixinEnvironment.Phase#MOD} mixin.<br>
+ * Recommend to group target mod name by package name. You can also get config instance from {@link org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin#injectConfig(org.spongepowered.asm.mixin.transformer.Config)}.
+ *
+ * If you what to block a mixin config, {@code GlobalProperties.get(GlobalProperties.Keys.CLEANROOM_DISABLE_MIXIN_CONFIGS)#add(String)}
+ */
+
+// TODO: Actually implement the logic
+@Deprecated
+public interface IMixinConfigHijacker {
+
+    /**
+     * Return a set of mixin config names to not be loaded by the mixin environment.
+     *
+     * @since 9.0
+     */
+    Set<String> getHijackedMixinConfigs();
+
+    /**
+     * Return a set of mixin config names to not be loaded by the mixin environment.
+     *
+     * @since 10.3
+     * @param context current context of the loading process. Mixin config will be null as it is not applicable.
+     */
+    default Set<String> getHijackedMixinConfigs(Context context) {
+        return getHijackedMixinConfigs();
+    }
+
+}


### PR DESCRIPTION
Include some MixinBooter 10.0+ classes, not implemented yet, but should mitigate some `NoClassDefFoundError`s.